### PR TITLE
Fix: Use Mollie::Customer::Subscription for subscription API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,8 +497,8 @@ All IDs default to random values (`tr_test<hex>`, etc.) when not specified.
 |---|---|---|
 | `stub_mollie_payment_create` | `Mollie::Payment.create` | `status: "open"`, random ID and checkout URL |
 | `stub_mollie_customer_and_payment_create` | `Mollie::Customer.create` + `Mollie::Payment.create` | Both with random IDs |
-| `stub_mollie_subscription_create` | `Mollie::Subscription.create` | `status: "active"`, random ID |
-| `stub_mollie_subscription_cancel` | `Mollie::Subscription.cancel` | Returns nil |
+| `stub_mollie_subscription_create` | `Mollie::Customer::Subscription.create` | `status: "active"`, random ID |
+| `stub_mollie_subscription_cancel` | `Mollie::Customer::Subscription.cancel` | Returns nil |
 | `stub_mollie_refund_create` | `Mollie::Refund.create` | `status: "queued"`, random ID |
 
 #### WebMock-based API stubs

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -29,12 +29,12 @@ module MolliePay
       raise MolliePay::MandateRequired, "No valid mandate on file" unless mollie_mandated?
 
       customer = mollie_customer!
-      ms = Mollie::Subscription.create(
-        customerId:  customer.mollie_id,
+      ms = Mollie::Customer::Subscription.create(
+        customer_id: customer.mollie_id,
         amount:      mollie_amount(amount),
         interval:    interval,
         description: description,
-        webhookUrl:  MolliePay.configuration.webhook_url
+        webhook_url: MolliePay.configuration.webhook_url
       )
       Subscription.create!(
         customer:  customer,
@@ -50,7 +50,7 @@ module MolliePay
       subscription = mollie_subscription
       raise MolliePay::SubscriptionNotFound, "No active subscription" unless subscription
 
-      Mollie::Subscription.cancel(
+      Mollie::Customer::Subscription.cancel(
         subscription.mollie_id,
         customer_id: mollie_customer.mollie_id
       )

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -40,7 +40,7 @@ module MolliePay
       end
     end
 
-    # Stub Mollie::Subscription.create.
+    # Stub Mollie::Customer::Subscription.create.
     #
     #   stub_mollie_subscription_create do
     #     subscription = @user.mollie_subscribe(amount: 2500, interval: "1 month", description: "Monthly")
@@ -49,17 +49,17 @@ module MolliePay
     #
     def stub_mollie_subscription_create(**overrides, &block)
       response = fake_mollie_subscription(**overrides)
-      Mollie::Subscription.stub(:create, response, &block)
+      Mollie::Customer::Subscription.stub(:create, response, &block)
     end
 
-    # Stub Mollie::Subscription.cancel.
+    # Stub Mollie::Customer::Subscription.cancel.
     #
     #   stub_mollie_subscription_cancel do
     #     @user.mollie_cancel_subscription
     #   end
     #
     def stub_mollie_subscription_cancel(&block)
-      Mollie::Subscription.stub(:cancel, nil, &block)
+      Mollie::Customer::Subscription.stub(:cancel, nil, &block)
     end
 
     # Stub Mollie::Refund.create.
@@ -153,32 +153,40 @@ module MolliePay
       WebMock.reset!
     end
 
-    # Stub POST /v2/subscriptions.
-    # The Mollie SDK sends customerId in the request body, not the URL.
+    # Stub POST /v2/customers/:customer_id/subscriptions.
     #
-    #   webmock_mollie_subscription_create do
+    #   webmock_mollie_subscription_create(customer_id: "cst_abc") do
     #     subscription = @user.mollie_subscribe(amount: 2500, interval: "1 month", description: "Monthly")
     #     assert_equal "active", subscription.status
     #   end
     #
-    def webmock_mollie_subscription_create(**overrides)
+    def webmock_mollie_subscription_create(customer_id: nil, **overrides)
       body = mollie_fixture("subscription", **overrides)
-      stub_request(:post, "#{MOLLIE_API_BASE}/subscriptions")
+      url_pattern = if customer_id
+        "#{MOLLIE_API_BASE}/customers/#{customer_id}/subscriptions"
+      else
+        %r{#{MOLLIE_API_BASE}/customers/cst_\w+/subscriptions}
+      end
+      stub_request(:post, url_pattern)
         .to_return(status: 201, body: body, headers: { "Content-Type" => "application/hal+json" })
       yield
     ensure
       WebMock.reset!
     end
 
-    # Stub DELETE /v2/subscriptions/:id.
-    # The Mollie SDK sends customerId in the request body, not the URL.
+    # Stub DELETE /v2/customers/:customer_id/subscriptions/:id.
     #
-    #   webmock_mollie_subscription_cancel(subscription_id: "sub_xyz") do
+    #   webmock_mollie_subscription_cancel(customer_id: "cst_abc", subscription_id: "sub_xyz") do
     #     @user.mollie_cancel_subscription
     #   end
     #
-    def webmock_mollie_subscription_cancel(subscription_id: "sub_test1234AB")
-      stub_request(:delete, "#{MOLLIE_API_BASE}/subscriptions/#{subscription_id}")
+    def webmock_mollie_subscription_cancel(customer_id: nil, subscription_id: "sub_test1234AB")
+      url_pattern = if customer_id
+        "#{MOLLIE_API_BASE}/customers/#{customer_id}/subscriptions/#{subscription_id}"
+      else
+        %r{#{MOLLIE_API_BASE}/customers/cst_\w+/subscriptions/#{subscription_id}}
+      end
+      stub_request(:delete, url_pattern)
         .to_return(status: 204, body: "", headers: {})
       yield
     ensure

--- a/test/lib/mollie_pay/test_helper_test.rb
+++ b/test/lib/mollie_pay/test_helper_test.rb
@@ -96,7 +96,9 @@ module MolliePay
     end
 
     test "webmock_mollie_subscription_create exercises full pipeline" do
-      webmock_mollie_subscription_create do
+      customer_id = @org.mollie_customer.mollie_id
+
+      webmock_mollie_subscription_create(customer_id: customer_id) do
         subscription = @org.mollie_subscribe(amount: 2500, interval: "1 month", description: "Monthly")
 
         assert_equal "sub_test1234AB", subscription.mollie_id
@@ -106,14 +108,36 @@ module MolliePay
       end
     end
 
+    test "webmock_mollie_subscription_create hits customer-nested endpoint" do
+      customer_id = @org.mollie_customer.mollie_id
+      expected_url = "#{MOLLIE_API_BASE}/customers/#{customer_id}/subscriptions"
+
+      webmock_mollie_subscription_create(customer_id: customer_id) do
+        @org.mollie_subscribe(amount: 2500, interval: "1 month", description: "Endpoint test")
+        assert_requested :post, expected_url
+      end
+    end
+
     test "webmock_mollie_subscription_cancel exercises full pipeline" do
       subscription = mollie_pay_subscriptions(:acme_monthly)
+      customer_id = @org.mollie_customer.mollie_id
 
-      webmock_mollie_subscription_cancel(subscription_id: subscription.mollie_id) do
+      webmock_mollie_subscription_cancel(customer_id: customer_id, subscription_id: subscription.mollie_id) do
         @org.mollie_cancel_subscription
       end
 
       assert_equal "canceled", subscription.reload.status
+    end
+
+    test "webmock_mollie_subscription_cancel hits customer-nested endpoint" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      customer_id = @org.mollie_customer.mollie_id
+      expected_url = "#{MOLLIE_API_BASE}/customers/#{customer_id}/subscriptions/#{subscription.mollie_id}"
+
+      webmock_mollie_subscription_cancel(customer_id: customer_id, subscription_id: subscription.mollie_id) do
+        @org.mollie_cancel_subscription
+        assert_requested :delete, expected_url
+      end
     end
 
     test "webmock_mollie_refund_create exercises full pipeline" do

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -195,6 +195,42 @@ module MolliePay
       end
     end
 
+    test "mollie_subscribe calls Mollie::Customer::Subscription.create with customer_id" do
+      received_args = nil
+      response = fake_mollie_subscription(id: "sub_api_class_test")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Customer::Subscription.stub(:create, fake_create) do
+        @org.mollie_subscribe(
+          amount: 2500,
+          interval: "1 month",
+          description: "API class test"
+        )
+      end
+
+      assert_not_nil received_args, "Mollie::Customer::Subscription.create was not called"
+      assert_equal @org.mollie_customer.mollie_id, received_args[:customer_id]
+      assert_equal({ currency: "EUR", value: "25.00" }, received_args[:amount])
+      assert_equal "1 month", received_args[:interval]
+      assert_equal "API class test", received_args[:description]
+    end
+
+    test "mollie_subscribe does not call top-level Mollie::Subscription" do
+      called = false
+      top_level_create = ->(**_args) { called = true; fake_mollie_subscription }
+
+      # Stub the correct class to succeed
+      response = fake_mollie_subscription(id: "sub_correct")
+      Mollie::Customer::Subscription.stub(:create, response) do
+        # Stub the wrong class to detect if it's called
+        Mollie::Subscription.stub(:create, top_level_create) do
+          @org.mollie_subscribe(amount: 2500, interval: "1 month", description: "Test")
+        end
+      end
+
+      assert_not called, "Top-level Mollie::Subscription.create should not be called"
+    end
+
     test "mollie_cancel_subscription raises without active subscription" do
       org = Organization.create!(name: "New Org", email: "new@org.nl")
       assert_raises(MolliePay::SubscriptionNotFound) do
@@ -212,6 +248,20 @@ module MolliePay
 
       assert_equal "canceled", subscription.reload.status
       assert_not_nil subscription.canceled_at
+    end
+
+    test "mollie_cancel_subscription calls Mollie::Customer::Subscription.cancel" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      received_id = nil
+      received_options = nil
+      fake_cancel = ->(id, **opts) { received_id = id; received_options = opts; nil }
+
+      Mollie::Customer::Subscription.stub(:cancel, fake_cancel) do
+        @org.mollie_cancel_subscription
+      end
+
+      assert_equal subscription.mollie_id, received_id
+      assert_equal @org.mollie_customer.mollie_id, received_options[:customer_id]
     end
 
     test "on_mollie_* hooks are defined and callable" do

--- a/test/tmp/generator_test/config/initializers/mollie_pay.rb
+++ b/test/tmp/generator_test/config/initializers/mollie_pay.rb
@@ -1,0 +1,6 @@
+MolliePay.configure do |config|
+  config.api_key               = ENV["MOLLIE_API_KEY"]
+  config.host                  = ENV["MOLLIE_HOST"] # e.g. "https://yourapp.com"
+  config.default_redirect_path = "/payments/:id"
+  config.currency              = "EUR"
+end


### PR DESCRIPTION
## Summary

- Fix `Billable#mollie_subscribe` to use `Mollie::Customer::Subscription.create` instead of `Mollie::Subscription.create`
- Fix `Billable#mollie_cancel_subscription` to use `Mollie::Customer::Subscription.cancel`
- Update test helper stubs and WebMock URL patterns to match

## Problem

The Mollie API requires subscriptions to be created under a customer endpoint:

```
POST /v2/customers/{customerId}/subscriptions
```

The current code uses `Mollie::Subscription.create(customerId: ...)` which hits `POST /v2/subscriptions` — an invalid endpoint that returns:

```
405 Method Not Allowed: Invalid resource endpoint
```

## Root Cause

The `mollie-api-ruby` gem's `Base.request` extracts `parent_id` from the data hash to build nested resource URLs. `Mollie::Customer::Subscription.parent_id` returns `:customer_id`, so passing `customer_id: "cst_xxx"` produces the correct path `customers/cst_xxx/subscriptions`. The top-level `Mollie::Subscription` class doesn't have this parent-child relationship.

## Test Plan

- [ ] Verify `mollie_subscribe` creates a subscription via `POST /v2/customers/{id}/subscriptions`
- [ ] Verify `mollie_cancel_subscription` cancels via `DELETE /v2/customers/{id}/subscriptions/{sub_id}`
- [ ] Verify test helper stubs work with the new class
- [ ] Verify WebMock stubs match the new URL pattern

Fixes #3