### PR TITLE
feat: Add optional method: parameter to mollie_pay_first and mollie_pay_once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,8 +145,8 @@ end
 ```
 
 Public methods:
-- `mollie_pay_once(amount:, description:, redirect_url: nil)` → returns `Payment` with `checkout_url`
-- `mollie_pay_first(amount:, description:, redirect_url: nil)` → returns `Payment` with `checkout_url`
+- `mollie_pay_once(amount:, description:, redirect_url: nil, method: nil)` → returns `Payment` with `checkout_url`
+- `mollie_pay_first(amount:, description:, redirect_url: nil, method: nil)` → returns `Payment` with `checkout_url`
 - `mollie_subscribe(amount:, interval:, description:)`
 - `mollie_cancel_subscription`
 - `mollie_refund(payment, amount: nil)`

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ created. The standard flow is:
 payment = current_organization.mollie_pay_first(
   amount:       1000, # 10.00 in cents
   description:  "Activation fee",
-  redirect_url: payment_url(payment) # optional if default_redirect_path is configured
+  redirect_url: payment_url(payment), # optional if default_redirect_path is configured
+  method:       "ideal" # optional — omit to let Mollie show all enabled methods
 )
 
 redirect_to payment.checkout_url
@@ -131,7 +132,8 @@ Raises `MolliePay::MandateRequired` if no valid mandate is on file.
 payment = current_organization.mollie_pay_once(
   amount:       7500,
   description:  "Extra service",
-  redirect_url: payment_url(payment) # optional if default_redirect_path is configured
+  redirect_url: payment_url(payment), # optional if default_redirect_path is configured
+  method:       "creditcard" # optional — omit to let Mollie show all enabled methods
 )
 
 redirect_to payment.checkout_url

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -17,12 +17,12 @@ module MolliePay
 
     # === Payments ===
 
-    def mollie_pay_once(amount:, description:, redirect_url: nil)
-      create_mollie_payment(amount:, description:, redirect_url:, sequence_type: "oneoff")
+    def mollie_pay_once(amount:, description:, redirect_url: nil, method: nil)
+      create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type: "oneoff")
     end
 
-    def mollie_pay_first(amount:, description:, redirect_url: nil)
-      create_mollie_payment(amount:, description:, redirect_url:, sequence_type: "first")
+    def mollie_pay_first(amount:, description:, redirect_url: nil, method: nil)
+      create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type: "first")
     end
 
     def mollie_subscribe(amount:, interval:, description:)
@@ -110,7 +110,7 @@ module MolliePay
 
     private
 
-    def create_mollie_payment(amount:, description:, redirect_url:, sequence_type:)
+    def create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type:)
       customer = mollie_customer!
 
       Payment.transaction do
@@ -130,7 +130,8 @@ module MolliePay
           redirectUrl:  resolved_redirect_url,
           webhookUrl:   MolliePay.configuration.webhook_url,
           customerId:   customer.mollie_id,
-          sequenceType: sequence_type
+          sequenceType: sequence_type,
+          method:       method
         )
 
         payment.update!(

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -112,6 +112,57 @@ module MolliePay
       MolliePay.configuration.default_redirect_path = nil
     end
 
+    test "mollie_pay_once passes method to Mollie API when provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_method_once")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_once(
+          amount: 3000,
+          description: "iDEAL payment",
+          redirect_url: "https://example.com/return",
+          method: "ideal"
+        )
+      end
+
+      assert_equal "ideal", received_args[:method]
+    end
+
+    test "mollie_pay_first passes method to Mollie API when provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_method_first")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_first(
+          amount: 1000,
+          description: "First iDEAL",
+          redirect_url: "https://example.com/return",
+          method: "ideal"
+        )
+      end
+
+      assert_equal "ideal", received_args[:method]
+      assert_equal "first", received_args[:sequenceType]
+    end
+
+    test "mollie_pay_once passes nil method when not provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_no_method")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_once(
+          amount: 3000,
+          description: "No method specified",
+          redirect_url: "https://example.com/return"
+        )
+      end
+
+      assert_nil received_args[:method]
+    end
+
     test "mollie_pay_once raises when no redirect_url and no default configured" do
       MolliePay.configuration.default_redirect_path = nil
 


### PR DESCRIPTION
## Summary

- Add optional `method:` keyword argument to `mollie_pay_first` and `mollie_pay_once` so callers can specify which Mollie payment method to use (e.g., `"ideal"`, `"creditcard"`)
- Defaults to `nil`, preserving existing auto-detect behavior
- Thread `method:` through private `create_mollie_payment` to `Mollie::Payment.create`

Closes #8

## Usage

```ruby
Current.user.mollie_pay_first(
  amount: 1000,
  description: "Activation fee",
  method: "ideal"
)
```

## Testing

- 3 new tests using lambda-capture pattern to verify method pass-through
- All 99 existing tests pass unchanged
- RuboCop clean (71 files, 0 offenses)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a backward-compatible parameter addition to a Ruby gem. No runtime behavior changes unless callers explicitly pass `method:`.