### PR TITLE
feat(billable): Support metadata pass-through on payment methods

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -32,12 +32,12 @@ module MolliePay
 
     # === Payments ===
 
-    def mollie_pay_once(amount:, description:, redirect_url: nil, method: nil)
-      create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type: "oneoff")
+    def mollie_pay_once(amount:, description:, redirect_url: nil, method: nil, metadata: nil)
+      create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type: "oneoff")
     end
 
-    def mollie_pay_first(amount:, description:, redirect_url: nil, method: nil)
-      create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type: "first")
+    def mollie_pay_first(amount:, description:, redirect_url: nil, method: nil, metadata: nil)
+      create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type: "first")
     end
 
     def mollie_subscribe(amount:, interval:, description:, start_date: nil)
@@ -123,7 +123,7 @@ module MolliePay
 
     private
 
-    def create_mollie_payment(amount:, description:, redirect_url:, method:, sequence_type:)
+    def create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type:)
       customer = mollie_customer!
 
       Payment.transaction do
@@ -144,7 +144,8 @@ module MolliePay
           webhookUrl:   MolliePay.configuration.webhook_url,
           customerId:   customer.mollie_id,
           sequenceType: sequence_type,
-          method:       method
+          method:       method,
+          metadata:     metadata
         )
 
         payment.update!(

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -163,6 +163,57 @@ module MolliePay
       assert_nil received_args[:method]
     end
 
+    test "mollie_pay_once passes metadata to Mollie API when provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_meta_once")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_once(
+          amount: 3000,
+          description: "With metadata",
+          redirect_url: "https://example.com/return",
+          metadata: { plan: "yearly", source: "checkout" }
+        )
+      end
+
+      assert_equal({ plan: "yearly", source: "checkout" }, received_args[:metadata])
+    end
+
+    test "mollie_pay_first passes metadata to Mollie API when provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_meta_first")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_first(
+          amount: 1000,
+          description: "First with metadata",
+          redirect_url: "https://example.com/return",
+          metadata: { plan: "monthly" }
+        )
+      end
+
+      assert_equal({ plan: "monthly" }, received_args[:metadata])
+      assert_equal "first", received_args[:sequenceType]
+    end
+
+    test "mollie_pay_once passes nil metadata when not provided" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_no_meta")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_once(
+          amount: 3000,
+          description: "No metadata",
+          redirect_url: "https://example.com/return"
+        )
+      end
+
+      assert_nil received_args[:metadata]
+    end
+
     test "mollie_pay_once raises when no redirect_url and no default configured" do
       MolliePay.configuration.default_redirect_path = nil
 


### PR DESCRIPTION
## Summary
- Add optional `metadata:` parameter to `mollie_pay_once` and `mollie_pay_first`
- Metadata is passed directly to the Mollie API (no local storage)
- Host apps read metadata back via `payment.mollie_record.metadata`
- Follows same unconditional pass-through pattern as `method:` parameter

## Test plan
- [x] Test metadata is forwarded to `Mollie::Payment.create` for `mollie_pay_once`
- [x] Test metadata is forwarded for `mollie_pay_first`
- [x] Test nil metadata doesn't break the call
- [x] All 106 existing tests pass
- [x] Rubocop passes

Closes #19