### PR TITLE
docs: Update all documentation for v0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ ProcessWebhookJob#perform
 Mollie sends only an `id` in the webhook POST body. We always fetch the full
 object from the API. The API key is the verification — no signature needed.
 
+**Webhook deduplication:** uses a unique database index on
+`mollie_pay_webhook_events.mollie_id` + `rescue ActiveRecord::RecordNotUnique`.
+This is the correct pattern — never use `exists?`-then-create (TOCTOU race
+condition).
+
 **Idempotency:** hooks fire only on actual status transitions. Duplicate
 webhooks update the record but do not re-trigger hooks. Transition timestamps
 are set once, never overwritten.
@@ -144,17 +149,32 @@ class Organization < ApplicationRecord
 end
 ```
 
+The `included` block sets up these associations automatically:
+
+```ruby
+included do
+  has_one  :mollie_customer,      class_name: "MolliePay::Customer", as: :owner, dependent: :destroy
+  has_many :mollie_subscriptions, through: :mollie_customer, source: :subscriptions, class_name: "MolliePay::Subscription"
+  has_many :mollie_payments,      through: :mollie_customer, source: :payments,      class_name: "MolliePay::Payment"
+  has_many :mollie_mandates,      through: :mollie_customer, source: :mandates,      class_name: "MolliePay::Mandate"
+end
+```
+
+**Note:** `class_name` is required on cross-namespace `has_many :through`
+associations. Rails cannot resolve engine-namespaced models when the including
+model is in the host app namespace.
+
 Public methods:
-- `mollie_pay_once(amount:, description:, redirect_url: nil, method: nil)` → returns `Payment` with `checkout_url`
-- `mollie_pay_first(amount:, description:, redirect_url: nil, method: nil)` → returns `Payment` with `checkout_url`
-- `mollie_subscribe(amount:, interval:, description:)`
+- `mollie_pay_once(amount:, description:, redirect_url: nil, method: nil, metadata: nil)` → returns `Payment` with `checkout_url`
+- `mollie_pay_first(amount:, description:, redirect_url: nil, method: nil, metadata: nil)` → returns `Payment` with `checkout_url`
+- `mollie_subscribe(amount:, interval:, description:, start_date: nil)` → returns `Subscription` (returns existing if pending/active)
 - `mollie_cancel_subscription`
 - `mollie_refund(payment, amount: nil)`
 - `mollie_subscribed?`
 - `mollie_mandated?`
 - `mollie_subscription`
 - `mollie_mandate`
-- `mollie_payments`
+- `mollie_payments` → `has_many :through` association (supports `includes`, `joins`, etc.)
 
 Event hooks (override in host model, all no-ops by default):
 - `on_mollie_payment_paid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.2.0] - 2026-03-17
+
+### Added
+- `has_many :mollie_subscriptions`, `:mollie_payments`, `:mollie_mandates` through
+  associations on Billable concern
+- `start_date:` optional parameter on `mollie_subscribe` — defer first subscription
+  charge when first payment covers the first period
+- `method:` parameter on `mollie_pay_first` and `mollie_pay_once` — specify Mollie
+  payment method (`"ideal"`, `"creditcard"`, etc.)
+- `metadata:` pass-through parameter on `mollie_pay_first` and `mollie_pay_once` —
+  arbitrary hash forwarded to the Mollie API
+- Idempotency guard on `mollie_subscribe` — returns existing subscription if one is
+  pending or active
+- Tutorial Parts 6-8 (payment method selection, through associations, production
+  hardening)
+
+### Fixed
+- `Payment.record_from_mollie` now links recurring payments to parent subscription
+  via `subscription_id`
+- Webhook event deduplication: database unique index on `mollie_id` +
+  `RecordNotUnique` rescue replaces application-level check
+
+### Changed
+- State query methods (`mollie_subscribed?`, `mollie_subscription`, `mollie_mandated?`,
+  `mollie_mandate`) use `has_many :through` associations instead of manual customer
+  delegation
+- Removed manual `mollie_payments` method from Billable — replaced by identical
+  `has_many :through` association (no host app changes needed)
+
+### Migration Required
+- Run `rails mollie_pay:install:migrations && rails db:migrate` for unique index on
+  `mollie_pay_webhook_events.mollie_id`
+
+## [0.1.0] - 2026-03-01
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ payment = current_organization.mollie_pay_first(
   amount:       1000, # 10.00 in cents
   description:  "Activation fee",
   redirect_url: payment_url(payment), # optional if default_redirect_path is configured
-  method:       "ideal" # optional — omit to let Mollie show all enabled methods
+  method:       "ideal",    # optional — omit to let Mollie show all enabled methods
+  metadata:     { plan: "monthly" } # optional — forwarded to Mollie API
 )
 
 redirect_to payment.checkout_url
@@ -120,11 +121,14 @@ ID interpolated). If you configured `default_redirect_path`, you can omit
 current_organization.mollie_subscribe(
   amount:      2500,        # 25.00 in cents
   interval:    "1 month",   # Mollie interval format
-  description: "Monthly plan"
+  description: "Monthly plan",
+  start_date:  Date.today + 1.month # optional — defer first charge
 )
 ```
 
-Raises `MolliePay::MandateRequired` if no valid mandate is on file.
+Raises `MolliePay::MandateRequired` if no valid mandate is on file. If a pending
+or active subscription already exists, returns the existing subscription without
+creating a duplicate (idempotency guard).
 
 **3. One-off payment — no mandate required**
 
@@ -164,7 +168,26 @@ org.mollie_subscribed?      # => true/false
 org.mollie_mandated?        # => true/false
 org.mollie_subscription     # => MolliePay::Subscription or nil
 org.mollie_mandate          # => MolliePay::Mandate or nil
-org.mollie_payments         # => ActiveRecord::Relation
+```
+
+### Through associations
+
+`mollie_payments`, `mollie_subscriptions`, and `mollie_mandates` are real
+`has_many :through` associations — they support full ActiveRecord chaining:
+
+```ruby
+org.mollie_subscriptions                 # all subscriptions
+org.mollie_subscriptions.active          # active only
+org.mollie_payments                      # all payments
+org.mollie_payments.paid                 # paid only
+org.mollie_payments.recurring            # recurring payments
+org.mollie_mandates                      # all mandates
+org.mollie_mandates.valid_status         # valid only
+
+# Eager loading for admin views (avoids N+1)
+User.includes(mollie_customer: :subscriptions).find_each do |user|
+  user.mollie_subscriptions.active       # no extra query
+end
 ```
 
 ### Fetching live Mollie data
@@ -210,10 +233,10 @@ POST https://yourapp.com/mollie_pay/webhooks
 ```
 POST /mollie_pay/webhooks              (from Mollie)
   → validate mollie_id format           (reject junk IDs with 422)
-  → skip if pending event already exists (deduplicate retries)
   → WebhookEvent.create!                (log the inbound ID)
   → ProcessWebhookJob.perform_later     (enqueue for async processing)
   → head :ok                            (respond immediately)
+  → rescue RecordNotUnique → head :ok   (deduplicate via unique index)
 
 ProcessWebhookJob:
   → skip if event already processed
@@ -225,10 +248,11 @@ ProcessWebhookJob:
 ```
 
 MolliePay responds immediately with `200 OK`, then processes asynchronously via
-Active Job. Duplicate webhooks from Mollie are deduplicated at the controller
-level — if a pending event for the same ID already exists, no new job is
-enqueued. On failure, the job retries with polynomial backoff (up to 5
-attempts). Resources not found on Mollie (404) are discarded, not retried.
+Active Job. Duplicate webhooks are deduplicated using a unique database index on
+`mollie_pay_webhook_events.mollie_id` — if a second webhook arrives for the same
+Mollie ID, the `INSERT` fails with `RecordNotUnique` and is silently ignored. On
+failure, the job retries with polynomial backoff (up to 5 attempts). Resources not
+found on Mollie (404) are discarded, not retried.
 
 ### Verification
 
@@ -589,11 +613,29 @@ config.active_job.queue_adapter = :solid_queue # or :sidekiq, :good_job, etc.
 
 Webhook jobs are enqueued on the `:default` queue. Processing includes:
 
-- **Deduplication:** duplicate webhooks are skipped at the controller level
+- **Deduplication:** duplicate webhooks are rejected via unique database index
 - **Retry policy:** polynomial backoff, up to 5 attempts on Mollie API and database errors
 - **Discard policy:** Mollie 404s (resource not found) are discarded immediately
 - **Idempotency guard:** already-processed events are skipped on retry
 - **Programming errors** (`NoMethodError`, etc.) bubble up immediately without marking the event as failed
+
+## Upgrading to v0.2
+
+Run the new migration for the webhook events unique index:
+
+```sh
+rails mollie_pay:install:migrations && rails db:migrate
+```
+
+**What changed:**
+- `mollie_payments` is now a real `has_many :through` association (previously a
+  manual method). Same interface, no host app changes needed.
+- `mollie_subscribe` accepts optional `start_date:` and has an idempotency guard.
+  Existing calls are unchanged.
+- `mollie_pay_once` and `mollie_pay_first` accept optional `method:` and `metadata:`
+  parameters. Existing calls are unchanged.
+- Webhook deduplication now uses a database unique index instead of an
+  application-level check. The new migration adds this index.
 
 ## License
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -271,6 +271,24 @@ mollie_customer&.subscriptions&.active&.first&.present?
 mollie_customer&.subscriptions&.active&.exists?
 ```
 
+### Webhook deduplication
+
+Use database unique constraints + `rescue ActiveRecord::RecordNotUnique` for
+webhook deduplication. Never use `exists?`-then-create — it has a TOCTOU race
+condition where concurrent requests both pass the `exists?` check.
+
+```ruby
+# Bad — TOCTOU race condition
+unless WebhookEvent.exists?(mollie_id: id)
+  WebhookEvent.create!(mollie_id: id)
+end
+
+# Good — database enforces uniqueness
+WebhookEvent.create!(mollie_id: id)
+rescue ActiveRecord::RecordNotUnique
+  # duplicate, safe to ignore
+```
+
 ### Time
 
 - `Time.current` — always, never `Time.now`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -728,6 +728,7 @@ Add the auto-subscribe hook to your `User` model:
 ```ruby
 # app/models/user.rb — add this method to the User class
 def on_mollie_first_payment_paid(payment)
+  return if mollie_subscribed?   # idempotency guard — prevents duplicate subscriptions on webhook retry
   return unless plan.present?
 
   plan_details = PricingController::PLANS[plan]
@@ -758,7 +759,7 @@ class BillingsController < ApplicationController
   def show
     @subscription = Current.user.mollie_subscription
     @mandate      = Current.user.mollie_mandate
-    @payments     = Current.user.mollie_payments.order(created_at: :desc).limit(10)
+    @payments     = Current.user.mollie_payments.order(created_at: :desc).limit(10) # real has_many :through association
   end
 end
 ```
@@ -1012,39 +1013,267 @@ end
 
 ---
 
-## Going further
+## Part 6: Payment method selection
 
-### Plan upgrades and downgrades
+Different payment methods create different mandate types and have different
+first-payment flows. Understanding this is important for a good user experience.
 
-To switch plans, cancel the current subscription and create a new one:
+### Payment method comparison
 
-```ruby
-Current.user.mollie_cancel_subscription
-Current.user.mollie_subscribe(
-  amount:      new_plan[:amount],
-  interval:    new_plan[:interval],
-  description: "Acme SaaS #{new_plan[:label]} subscription"
-)
+| Payment Method | Mollie `method` | First Payment | Mandate Type | Recurring Via | Subscription Start |
+|---|---|---|---|---|---|
+| iDEAL | `"ideal"` | €0.01 | SEPA Direct Debit | SEPA DD | Immediate |
+| Credit Card | `"creditcard"` | Full plan amount | Credit Card | Credit Card | Next period |
+| SEPA Direct Debit | `"ideal"` (via iDEAL) | €0.01 | SEPA Direct Debit | SEPA DD | Immediate |
+
+### Why credit card charges the full amount
+
+Credit card mandates support charging the full plan amount as the first payment.
+This IS the first subscription charge. The subscription then starts at the next
+period using `start_date:` to avoid double-charging.
+
+### Why SEPA DD uses iDEAL
+
+SEPA Direct Debit mandates are created through iDEAL — this is standard Mollie
+practice. The €0.01 payment establishes the mandate, then SEPA DD handles
+recurring charges.
+
+### Adding payment method selection
+
+Update your pricing view to include method radio buttons:
+
+```erb
+<%# app/views/pricing/show.html.erb — inside each plan card %>
+<%= form_with url: subscription_setup_path, data: { turbo: false } do |f| %>
+  <%= f.hidden_field :plan, value: plan_key %>
+
+  <div class="space-y-2 mt-4">
+    <label class="flex items-center gap-2">
+      <%= f.radio_button :method, "ideal", checked: true, class: "accent-blue-600" %>
+      iDEAL (€0.01 setup)
+    </label>
+    <label class="flex items-center gap-2">
+      <%= f.radio_button :method, "creditcard", class: "accent-blue-600" %>
+      Credit Card (first charge is full amount)
+    </label>
+  </div>
+
+  <%= f.submit "Subscribe", class: "mt-4 w-full bg-blue-600 text-white py-2 rounded" %>
+<% end %>
 ```
 
-Mollie handles proration at the payment level — the next charge will be for the
-new amount on the new interval.
+> **Important:** The `data: { turbo: false }` attribute is essential. Rails 8
+> includes Turbo Drive by default, which intercepts form submissions via
+> `fetch()`. Cross-origin redirects (to Mollie's checkout) are silently blocked
+> by the browser. This attribute disables Turbo for this form.
 
-### Refunds
-
-Refund a payment from the billing dashboard or an admin panel:
+### Updating the controller
 
 ```ruby
-Current.user.mollie_refund(payment)              # full refund
-Current.user.mollie_refund(payment, amount: 500) # partial — €5.00
+# app/controllers/subscription_setups_controller.rb
+class SubscriptionSetupsController < ApplicationController
+  ALLOWED_METHODS = %w[ideal creditcard].freeze
+
+  def create
+    method = params[:method]
+    method = nil unless ALLOWED_METHODS.include?(method)
+
+    plan = PricingController::PLANS[params[:plan]]
+    return redirect_to pricing_path, alert: "Invalid plan" unless plan
+
+    # Credit card: charge full amount as first payment
+    # Other methods: charge €0.01 to establish mandate
+    amount = method == "creditcard" ? plan[:amount] : 1
+
+    Current.user.update!(plan: params[:plan])
+    payment = Current.user.mollie_pay_first(
+      amount:       amount,
+      description:  "Acme SaaS — #{plan[:label]} setup",
+      redirect_url: billing_url,
+      method:       method
+    )
+    redirect_to payment.checkout_url, allow_other_host: true
+  end
+end
 ```
 
-### Production deployment
+### Handling the webhook callback
 
-Before going live:
+Update `on_mollie_first_payment_paid` to detect full-amount first payments and
+pass `start_date:` to avoid double-charging:
+
+```ruby
+# app/models/user.rb
+def on_mollie_first_payment_paid(payment)
+  return if mollie_subscribed?
+  return unless plan.present?
+
+  plan_details = PricingController::PLANS[plan]
+  return unless plan_details
+
+  # If first payment covered the full amount (credit card flow),
+  # start subscription at next period to avoid double-charging
+  start_date = if payment.amount >= plan_details[:amount]
+    Date.today + plan_details[:interval_duration]
+  end
+
+  mollie_subscribe(
+    amount:      plan_details[:amount],
+    interval:    plan_details[:interval],
+    description: "Acme SaaS #{plan_details[:label]} subscription",
+    start_date:  start_date
+  )
+end
+```
+
+You will need a helper method to compute the next period start date. Add to your
+`PricingController::PLANS` hash:
+
+```ruby
+PLANS = {
+  "monthly" => { label: "Monthly", amount: 2500, interval: "1 month", interval_duration: 1.month },
+  "yearly"  => { label: "Yearly",  amount: 25000, interval: "12 months", interval_duration: 1.year }
+}.freeze
+```
+
+---
+
+## Part 7: Using through associations
+
+MolliePay provides `has_many :through` associations that give your billable model
+direct access to payments, subscriptions, and mandates without navigating through
+the customer.
+
+### Before and after
+
+```ruby
+# Before (v0.1) — safe navigation required
+user.mollie_customer&.subscriptions&.active&.exists?
+user.mollie_customer&.payments || MolliePay::Payment.none
+
+# After (v0.2) — through associations, nil-safe
+user.mollie_subscriptions.active.exists?
+user.mollie_payments  # real association, works even without a customer
+```
+
+### Billing dashboard with real associations
+
+Since `mollie_payments` is a real ActiveRecord association, it supports full
+chaining:
+
+```ruby
+# app/controllers/billings_controller.rb
+@payments = Current.user.mollie_payments.order(created_at: :desc).limit(10)
+```
+
+### Eager loading for admin views
+
+When displaying multiple users with their subscription status, use `includes`
+to avoid N+1 queries:
+
+```ruby
+# app/controllers/admin/users_controller.rb
+@users = User.includes(mollie_customer: :subscriptions).page(params[:page])
+
+# In the view — no extra query per user
+@users.each do |user|
+  user.mollie_subscriptions.active.exists?  # uses preloaded data
+end
+```
+
+### Available scopes
+
+All scopes can be chained on the through associations:
+
+| Association | Scopes |
+|---|---|
+| `mollie_subscriptions` | `.active`, `.pending`, `.canceled`, `.suspended`, `.completed` |
+| `mollie_payments` | `.paid`, `.failed`, `.open`, `.recurring`, `.first_payments` |
+| `mollie_mandates` | `.valid_status`, `.pending` |
+
+---
+
+## Part 8: Production hardening
+
+Before going live, implement these patterns to handle real-world edge cases.
+
+### Idempotency guard on first payment callback
+
+The `ProcessWebhookJob` retries up to 5 times with polynomial backoff. Without
+a guard, a retry after partial success creates a duplicate Mollie subscription —
+meaning the customer gets charged twice on a recurring basis.
+
+```ruby
+def on_mollie_first_payment_paid(payment)
+  return if mollie_subscribed?   # essential — prevents duplicate subscriptions
+  # ... rest of subscription creation
+end
+```
+
+Additionally, `mollie_subscribe` itself has a built-in idempotency guard — it
+returns the existing subscription if one is pending or active. This provides
+defense-in-depth.
+
+### Webhook deduplication
+
+MolliePay v0.2 uses a unique database index on `mollie_pay_webhook_events.mollie_id`:
+
+```ruby
+# Old pattern (v0.1) — TOCTOU race condition
+unless WebhookEvent.pending.exists?(mollie_id:)
+  WebhookEvent.create!(mollie_id:)
+end
+
+# New pattern (v0.2) — database enforces uniqueness
+WebhookEvent.create!(mollie_id:)
+rescue ActiveRecord::RecordNotUnique
+  head :ok  # duplicate, safe to ignore
+```
+
+Why this matters: Mollie retries webhooks, and concurrent deliveries can arrive
+simultaneously. The `exists?`-then-create pattern has a time-of-check to
+time-of-use (TOCTOU) race condition where two concurrent requests both pass the
+`exists?` check. The unique index + rescue pattern is atomic.
+
+### Error handling in controllers
+
+Add a rescue pattern for all controllers that call the Mollie API:
+
+```ruby
+rescue Mollie::RequestError, MolliePay::ConfigurationError => e
+  Rails.logger.error("Mollie API error: #{e.message}")
+  redirect_to pricing_path, alert: "Payment service unavailable. Please try again."
+end
+```
+
+### Turbo Drive and external redirects
+
+Rails 8 includes Turbo Drive by default. Turbo intercepts form submissions via
+`fetch()`. Cross-origin redirects (to Mollie's checkout page) are silently
+blocked by the browser.
+
+**Fix:** Add `data: { turbo: false }` on every form that redirects to Mollie:
+
+```erb
+<%= form_with url: subscription_setup_path, data: { turbo: false } do |f| %>
+  <%# ... %>
+<% end %>
+```
+
+This applies to subscription setup forms, one-off payment forms, and any form
+that ultimately redirects to `payment.checkout_url`.
+
+Also use `allow_other_host: true` in your controller redirects:
+
+```ruby
+redirect_to payment.checkout_url, allow_other_host: true
+```
+
+### Production deployment checklist
 
 1. Switch to a `live_` API key
 2. Set `host` to your real domain with HTTPS (e.g. `https://yourapp.com`)
 3. Configure a proper queue backend (Solid Queue, Sidekiq, etc.)
 4. Add rate limiting to the webhook endpoint (see README)
 5. Set up monitoring for failed webhook jobs
+6. Test each payment method in Mollie's test mode before going live


### PR DESCRIPTION
## Summary
- **AGENTS.md**: Update Billable concern section with through associations, `metadata:`, `start_date:`, webhook dedup pattern, `class_name` note
- **STYLE.md**: Add webhook dedup convention (unique index + `RecordNotUnique`)
- **CHANGELOG.md**: New file following Keep a Changelog format
- **README.md**: Document through associations, `start_date:`, `metadata:`, updated webhook dedup, add "Upgrading to v0.2" section
- **Tutorial**: Add Part 6 (payment method selection with iDEAL/creditcard), Part 7 (through associations), Part 8 (production hardening), update Parts 3-5

## Test plan
- [x] All 109 tests pass (no code changes, docs only)
- [x] Rubocop passes (no Ruby changes)

Closes #21, closes #22, closes #23, closes #24, closes #25, closes #26, closes #27