### PR TITLE
chore: Bump version to 0.2.0 and release

### DIFF
--- a/lib/mollie_pay/version.rb
+++ b/lib/mollie_pay/version.rb
@@ -1,3 +1,3 @@
 module MolliePay
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Summary
- Bump version in `lib/mollie_pay/version.rb` from `0.1.0` to `0.2.0`
- All v0.2 features, test helpers, and documentation are merged

## v0.2.0 includes
- **Features**: metadata pass-through (#19, PR #30), subscribe idempotency guard (#20, PR #31)
- **Test helpers**: Updated docs with metadata/start_date examples (#28, PR #32)
- **Documentation**: README, AGENTS.md, STYLE.md, CHANGELOG.md, tutorial Parts 6-8 (#21-27, PR #33)
- **Previously merged**: Through associations, start_date, method: parameter, webhook dedup (#15, #16, #17)

## After merge
- Tag: `git tag v0.2.0`
- GitHub release with CHANGELOG content

## Test plan
- [x] All 109 tests pass
- [x] Rubocop passes

Closes #29