### PR TITLE
feat(billable): Add idempotency guard to mollie_subscribe

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -43,6 +43,9 @@ module MolliePay
     def mollie_subscribe(amount:, interval:, description:, start_date: nil)
       raise MolliePay::MandateRequired, "No valid mandate on file" unless mollie_mandated?
 
+      existing = mollie_subscriptions.where(status: %w[pending active]).first
+      return existing if existing
+
       customer = mollie_customer!
       params = {
         customer_id: customer.mollie_id,

--- a/test/lib/mollie_pay/test_helper_test.rb
+++ b/test/lib/mollie_pay/test_helper_test.rb
@@ -96,6 +96,7 @@ module MolliePay
     end
 
     test "webmock_mollie_subscription_create exercises full pipeline" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
       customer_id = @org.mollie_customer.mollie_id
 
       webmock_mollie_subscription_create(customer_id: customer_id) do
@@ -109,6 +110,7 @@ module MolliePay
     end
 
     test "webmock_mollie_subscription_create hits customer-nested endpoint" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
       customer_id = @org.mollie_customer.mollie_id
       expected_url = "#{MOLLIE_API_BASE}/customers/#{customer_id}/subscriptions"
 

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -275,6 +275,47 @@ module MolliePay
       end
     end
 
+    test "mollie_subscribe returns existing active subscription" do
+      existing = mollie_pay_subscriptions(:acme_monthly)
+      assert_equal "active", existing.status
+
+      result = @org.mollie_subscribe(
+        amount: 5000,
+        interval: "1 year",
+        description: "Different plan"
+      )
+
+      assert_equal existing, result
+    end
+
+    test "mollie_subscribe returns existing pending subscription" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      subscription.update!(status: "pending")
+
+      result = @org.mollie_subscribe(
+        amount: 2500,
+        interval: "1 month",
+        description: "Monthly plan"
+      )
+
+      assert_equal subscription, result
+    end
+
+    test "mollie_subscribe creates new when only canceled subscriptions exist" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
+      stub_mollie_subscription_create(id: "sub_after_cancel") do
+        subscription = @org.mollie_subscribe(
+          amount: 2500,
+          interval: "1 month",
+          description: "Re-subscribe"
+        )
+
+        assert_equal "sub_after_cancel", subscription.mollie_id
+        assert_equal "active", subscription.status
+      end
+    end
+
     test "mollie_subscribe raises without mandate" do
       org = Organization.create!(name: "New Org", email: "new@org.nl")
       assert_raises(MolliePay::MandateRequired) do
@@ -283,6 +324,8 @@ module MolliePay
     end
 
     test "mollie_subscribe creates a subscription" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
       stub_mollie_subscription_create(id: "sub_new123") do
         subscription = @org.mollie_subscribe(
           amount: 2500,
@@ -298,6 +341,8 @@ module MolliePay
     end
 
     test "mollie_subscribe calls Mollie::Customer::Subscription.create with customer_id" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
       received_args = nil
       response = fake_mollie_subscription(id: "sub_api_class_test")
       fake_create = ->(**args) { received_args = args; response }
@@ -318,6 +363,8 @@ module MolliePay
     end
 
     test "mollie_subscribe does not call top-level Mollie::Subscription" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
       called = false
       top_level_create = ->(**_args) { called = true; fake_mollie_subscription }
 


### PR DESCRIPTION
## Summary
- Return existing subscription if one is pending or active
- Mandate check first (raises), idempotency guard second (early return)
- Prevents duplicate Mollie subscriptions from double-clicks or retries

## Test plan
- [x] Test returns existing active subscription
- [x] Test returns existing pending subscription
- [x] Test creates new when only canceled exist
- [x] All 109 tests pass, rubocop passes

Closes #20