### PR TITLE
chore: Bump version to 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    mollie_pay (0.1.0)
+    mollie_pay (0.2.0)
       mollie-api-ruby (>= 4.19.0)
       rails (>= 8.1.2)
 
@@ -350,7 +350,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   mollie-api-ruby (4.19.0)
-  mollie_pay (0.1.0)
+  mollie_pay (0.2.0)
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/mollie_pay/version.rb
+++ b/lib/mollie_pay/version.rb
@@ -1,3 +1,3 @@
 module MolliePay
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Summary
- Bump version in `lib/mollie_pay/version.rb` to `0.2.0`

## Test plan
- [x] All 109 tests pass, rubocop passes

Closes #29