### PR TITLE
feat(subscriptions): Add named subscriptions for multi-subscription support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,14 +167,19 @@ model is in the host app namespace.
 Public methods:
 - `mollie_pay_once(amount:, description:, redirect_url: nil, method: nil, metadata: nil)` → returns `Payment` with `checkout_url`
 - `mollie_pay_first(amount:, description:, redirect_url: nil, method: nil, metadata: nil)` → returns `Payment` with `checkout_url`
-- `mollie_subscribe(amount:, interval:, description:, start_date: nil)` → returns `Subscription` (returns existing if pending/active)
-- `mollie_cancel_subscription`
+- `mollie_subscribe(amount:, interval:, description:, start_date: nil, name: "default")` → returns `Subscription` (returns existing if pending/active for that name)
+- `mollie_cancel_subscription(name: "default")`
 - `mollie_refund(payment, amount: nil)`
-- `mollie_subscribed?`
+- `mollie_subscribed?(name: "default")`
 - `mollie_mandated?`
-- `mollie_subscription`
+- `mollie_subscription(name: "default")`
 - `mollie_mandate`
 - `mollie_payments` → `has_many :through` association (supports `includes`, `joins`, etc.)
+
+**Named subscriptions:** All subscription methods accept `name:` with a default
+of `"default"`. This allows multiple concurrent subscriptions per customer
+(e.g., `"default"` + `"analytics_addon"`). A partial unique index prevents
+duplicate active/pending subscriptions per name per customer.
 
 Event hooks (override in host model, all no-ops by default):
 - `on_mollie_payment_paid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.0] - 2026-03-17
+
+### Added
+- Named subscriptions: `name` column on subscriptions (default: `"default"`)
+  enables multiple concurrent subscriptions per customer
+- `name:` keyword argument on `mollie_subscribe`, `mollie_cancel_subscription`,
+  `mollie_subscribed?`, and `mollie_subscription` (default: `"default"`)
+- `Subscription::ACTIVE_STATUSES` constant for pending/active status checks
+- `named` scope on Subscription model
+- Partial unique index on `[customer_id, name]` WHERE status IN
+  ('pending', 'active') — database-level idempotency guarantee
+- Race condition handling: orphaned Mollie subscriptions are canceled when
+  `RecordNotUnique` is raised during concurrent creates
+- Subscription name stored in Mollie metadata for webhook recovery
+
+### Migration Required
+- Run `rails mollie_pay:install:migrations && rails db:migrate` for the
+  `name` column and partial unique index on subscriptions
+
 ## [0.2.0] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,8 +127,30 @@ current_organization.mollie_subscribe(
 ```
 
 Raises `MolliePay::MandateRequired` if no valid mandate is on file. If a pending
-or active subscription already exists, returns the existing subscription without
-creating a duplicate (idempotency guard).
+or active subscription with the same name already exists, returns the existing
+subscription without creating a duplicate (idempotency guard).
+
+**Named subscriptions** — multiple concurrent subscriptions per customer:
+
+```ruby
+# Base plan
+current_organization.mollie_subscribe(
+  amount: 2500, interval: "1 month", description: "Base plan"
+)
+
+# Add-on (different name)
+current_organization.mollie_subscribe(
+  amount: 1000, interval: "1 month", description: "Analytics",
+  name: "analytics_addon"
+)
+
+# Query and cancel by name
+current_organization.mollie_subscribed?(name: "analytics_addon")  # => true
+current_organization.mollie_cancel_subscription(name: "analytics_addon")
+```
+
+All subscription methods default to `name: "default"` when no name is given,
+so existing code works unchanged.
 
 **3. One-off payment — no mandate required**
 
@@ -636,6 +658,23 @@ rails mollie_pay:install:migrations && rails db:migrate
   parameters. Existing calls are unchanged.
 - Webhook deduplication now uses a database unique index instead of an
   application-level check. The new migration adds this index.
+
+## Upgrading to v0.3
+
+Run the new migration for the subscription name column:
+
+```sh
+rails mollie_pay:install:migrations && rails db:migrate
+```
+
+**What changed:**
+- Subscriptions now have a `name` column (default: `"default"`). Existing
+  subscriptions are unchanged — they get `name = "default"` automatically.
+- All subscription methods (`mollie_subscribe`, `mollie_cancel_subscription`,
+  `mollie_subscribed?`, `mollie_subscription`) accept optional `name:` keyword.
+  Existing calls without `name:` work identically.
+- A partial unique index prevents duplicate active/pending subscriptions per
+  name per customer — the idempotency guard is now database-backed.
 
 ## License
 

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -40,10 +40,10 @@ module MolliePay
       create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type: "first")
     end
 
-    def mollie_subscribe(amount:, interval:, description:, start_date: nil)
+    def mollie_subscribe(amount:, interval:, description:, start_date: nil, name: "default")
       raise MolliePay::MandateRequired, "No valid mandate on file" unless mollie_mandated?
 
-      existing = mollie_subscriptions.where(status: %w[pending active]).first
+      existing = mollie_subscriptions.where(status: Subscription::ACTIVE_STATUSES, name: name).first
       return existing if existing
 
       customer = mollie_customer!
@@ -52,7 +52,8 @@ module MolliePay
         amount:      mollie_amount(amount),
         interval:    interval,
         description: description,
-        webhook_url: MolliePay.configuration.webhook_url
+        webhook_url: MolliePay.configuration.webhook_url,
+        metadata:    { mollie_pay_name: name }
       }
       params[:start_date] = start_date.to_s if start_date
       ms = Mollie::Customer::Subscription.create(**params)
@@ -62,12 +63,16 @@ module MolliePay
         status:    ms.status,
         amount:    amount,
         currency:  MolliePay.configuration.currency,
-        interval:  interval
+        interval:  interval,
+        name:      name
       )
+    rescue ActiveRecord::RecordNotUnique
+      Mollie::Customer::Subscription.cancel(ms.id, customer_id: customer.mollie_id)
+      mollie_subscriptions.where(status: Subscription::ACTIVE_STATUSES, name: name).first!
     end
 
-    def mollie_cancel_subscription
-      subscription = mollie_subscription
+    def mollie_cancel_subscription(name: "default")
+      subscription = mollie_subscriptions.active.named(name).first
       raise MolliePay::SubscriptionNotFound, "No active subscription" unless subscription
 
       Mollie::Customer::Subscription.cancel(
@@ -94,16 +99,16 @@ module MolliePay
 
     # === State queries ===
 
-    def mollie_subscribed?
-      mollie_subscriptions.active.exists?
+    def mollie_subscribed?(name: "default")
+      mollie_subscriptions.active.named(name).exists?
     end
 
     def mollie_mandated?
       mollie_mandates.valid_status.exists?
     end
 
-    def mollie_subscription
-      mollie_subscriptions.active.first
+    def mollie_subscription(name: "default")
+      mollie_subscriptions.active.named(name).first
     end
 
     def mollie_mandate

--- a/app/models/mollie_pay/subscription.rb
+++ b/app/models/mollie_pay/subscription.rb
@@ -1,6 +1,7 @@
 module MolliePay
   class Subscription < ApplicationRecord
-    STATUSES = %w[ pending active suspended canceled completed ].freeze
+    STATUSES        = %w[ pending active suspended canceled completed ].freeze
+    ACTIVE_STATUSES = %w[ pending active ].freeze
 
     belongs_to :customer
     has_many   :payments, dependent: :nullify
@@ -10,29 +11,39 @@ module MolliePay
     validates :amount,    presence: true, numericality: { greater_than: 0 }
     validates :currency,  presence: true
     validates :interval,  presence: true
+    validates :name,      presence: true
 
     scope :active,     -> { where(status: "active") }
     scope :pending,    -> { where(status: "pending") }
     scope :suspended,  -> { where(status: "suspended") }
     scope :canceled,   -> { where(status: "canceled") }
     scope :completed,  -> { where(status: "completed") }
+    scope :named,      ->(name) { where(name: name) }
 
     def self.record_from_mollie(ms)
       customer = Customer.includes(:owner).find_by!(mollie_id: ms.customer_id)
       subscription = find_or_initialize_by(mollie_id: ms.id)
       previous_status = subscription.status
 
-      subscription.update!(
+      attrs = {
         customer:    customer,
         status:      ms.status,
         amount:      mollie_value_to_cents(ms.amount),
         currency:    ms.amount.currency,
         interval:    ms.interval,
         canceled_at: ms.status == "canceled" && !subscription.canceled_at ? Time.current : subscription.canceled_at
-      )
+      }
 
+      # Only set name on new records (never overwrite existing name from webhooks)
+      if subscription.new_record?
+        attrs[:name] = ms.metadata&.dig("mollie_pay_name") || "default"
+      end
+
+      subscription.update!(**attrs)
       subscription.notify_billable if subscription.status != previous_status
       subscription
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(mollie_id: ms.id)
     end
 
     def notify_billable

--- a/db/migrate/20260318100000_add_name_to_mollie_pay_subscriptions.rb
+++ b/db/migrate/20260318100000_add_name_to_mollie_pay_subscriptions.rb
@@ -1,0 +1,12 @@
+class AddNameToMolliePaySubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mollie_pay_subscriptions, :name, :string, null: false, default: "default"
+
+    # Partial unique index: one active/pending subscription per name per customer.
+    # Must match Subscription::ACTIVE_STATUSES constant.
+    add_index :mollie_pay_subscriptions, [ :customer_id, :name ],
+              unique: true,
+              where: "status IN ('pending', 'active')",
+              name: "idx_mollie_subs_unique_active_per_customer_name"
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_17_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_18_100000) do
   create_table "mollie_pay_customers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "mollie_id", null: false
@@ -76,8 +76,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_17_100000) do
     t.integer "customer_id", null: false
     t.string "interval", null: false
     t.string "mollie_id", null: false
+    t.string "name", default: "default", null: false
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
+    t.index ["customer_id", "name"], name: "idx_mollie_subs_unique_active_per_customer_name", unique: true, where: "status IN ('pending', 'active')"
     t.index ["customer_id", "status"], name: "index_mollie_pay_subscriptions_on_customer_id_and_status"
     t.index ["customer_id"], name: "index_mollie_pay_subscriptions_on_customer_id"
     t.index ["mollie_id"], name: "index_mollie_pay_subscriptions_on_mollie_id", unique: true

--- a/test/fixtures/mollie_pay/subscriptions.yml
+++ b/test/fixtures/mollie_pay/subscriptions.yml
@@ -5,3 +5,13 @@ acme_monthly:
   amount: 2500
   currency: EUR
   interval: "1 month"
+  name: default
+
+acme_addon:
+  customer: acme
+  mollie_id: sub_acme_addon
+  status: active
+  amount: 1000
+  currency: EUR
+  interval: "1 month"
+  name: analytics_addon

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -413,6 +413,105 @@ module MolliePay
       assert_equal @org.mollie_customer.mollie_id, received_options[:customer_id]
     end
 
+    # === Named subscriptions ===
+
+    test "mollie_subscribe creates named subscription" do
+      stub_mollie_subscription_create(id: "sub_new_addon") do
+        subscription = @org.mollie_subscribe(
+          amount: 1000,
+          interval: "1 month",
+          description: "Analytics addon",
+          name: "reporting"
+        )
+
+        assert_equal "sub_new_addon", subscription.mollie_id
+        assert_equal "reporting", subscription.name
+      end
+    end
+
+    test "mollie_subscribe passes name in Mollie metadata" do
+      received_args = nil
+      response = fake_mollie_subscription(id: "sub_meta_test")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Customer::Subscription.stub(:create, fake_create) do
+        @org.mollie_subscribe(
+          amount: 1000,
+          interval: "1 month",
+          description: "With metadata",
+          name: "reporting"
+        )
+      end
+
+      assert_equal({ mollie_pay_name: "reporting" }, received_args[:metadata])
+    end
+
+    test "mollie_subscribe idempotency guard is scoped by name" do
+      # acme_monthly (default) and acme_addon (analytics_addon) are both active
+      assert @org.mollie_subscribed?(name: "default")
+      assert @org.mollie_subscribed?(name: "analytics_addon")
+
+      # Creating a new name should work (not return existing default)
+      stub_mollie_subscription_create(id: "sub_new_name") do
+        subscription = @org.mollie_subscribe(
+          amount: 500,
+          interval: "1 month",
+          description: "New addon",
+          name: "reporting"
+        )
+
+        assert_equal "sub_new_name", subscription.mollie_id
+        assert_equal "reporting", subscription.name
+      end
+    end
+
+    test "mollie_subscribe returns existing for same name" do
+      existing = mollie_pay_subscriptions(:acme_addon)
+      assert_equal "analytics_addon", existing.name
+
+      result = @org.mollie_subscribe(
+        amount: 9999,
+        interval: "1 year",
+        description: "Different params",
+        name: "analytics_addon"
+      )
+
+      assert_equal existing, result
+    end
+
+    test "mollie_subscribed? scoped by name" do
+      assert @org.mollie_subscribed?(name: "default")
+      assert @org.mollie_subscribed?(name: "analytics_addon")
+      assert_not @org.mollie_subscribed?(name: "nonexistent")
+    end
+
+    test "mollie_subscription scoped by name" do
+      assert_equal mollie_pay_subscriptions(:acme_monthly), @org.mollie_subscription(name: "default")
+      assert_equal mollie_pay_subscriptions(:acme_addon), @org.mollie_subscription(name: "analytics_addon")
+      assert_nil @org.mollie_subscription(name: "nonexistent")
+    end
+
+    test "mollie_cancel_subscription cancels named subscription" do
+      addon = mollie_pay_subscriptions(:acme_addon)
+      assert addon.active?
+
+      fake_cancel = ->(id, **_opts) { nil }
+      Mollie::Customer::Subscription.stub(:cancel, fake_cancel) do
+        @org.mollie_cancel_subscription(name: "analytics_addon")
+      end
+
+      assert_equal "canceled", addon.reload.status
+      assert_not_nil addon.canceled_at
+      # Default subscription should still be active
+      assert @org.mollie_subscribed?(name: "default")
+    end
+
+    test "mollie_cancel_subscription raises for nonexistent name" do
+      assert_raises(MolliePay::SubscriptionNotFound) do
+        @org.mollie_cancel_subscription(name: "nonexistent")
+      end
+    end
+
     test "on_mollie_* hooks are defined and callable" do
       payment      = mollie_pay_payments(:acme_first)
       subscription = mollie_pay_subscriptions(:acme_monthly)

--- a/test/models/mollie_pay/customer_test.rb
+++ b/test/models/mollie_pay/customer_test.rb
@@ -22,9 +22,10 @@ module MolliePay
       assert mollie_pay_customers(:acme).mandated?
     end
 
-    test "active_subscription returns first active subscription" do
+    test "active_subscription returns an active subscription" do
       sub = mollie_pay_customers(:acme).active_subscription
-      assert_equal mollie_pay_subscriptions(:acme_monthly), sub
+      assert sub.active?
+      assert_includes [ mollie_pay_subscriptions(:acme_monthly), mollie_pay_subscriptions(:acme_addon) ], sub
     end
   end
 end

--- a/test/models/mollie_pay/subscription_test.rb
+++ b/test/models/mollie_pay/subscription_test.rb
@@ -27,6 +27,8 @@ module MolliePay
     end
 
     test "record_from_mollie creates subscription from mollie object" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
       mollie_sub = stub_mollie_subscription(
         id:          "sub_new456",
         status:      "active",
@@ -79,16 +81,83 @@ module MolliePay
       assert_equal "canceled", existing.reload.status
     end
 
+    test "name validates presence" do
+      sub = mollie_pay_subscriptions(:acme_monthly)
+      sub.name = ""
+      assert_not sub.valid?
+      assert_includes sub.errors[:name], "can't be blank"
+    end
+
+    test "named scope filters by name" do
+      assert_includes Subscription.named("default"), mollie_pay_subscriptions(:acme_monthly)
+      assert_includes Subscription.named("analytics_addon"), mollie_pay_subscriptions(:acme_addon)
+      assert_empty Subscription.named("nonexistent")
+    end
+
+    test "record_from_mollie preserves existing name" do
+      existing = mollie_pay_subscriptions(:acme_monthly)
+      assert_equal "default", existing.name
+
+      mollie_sub = stub_mollie_subscription(
+        id:          existing.mollie_id,
+        status:      "active",
+        customer_id: mollie_pay_customers(:acme).mollie_id,
+        interval:    "1 month",
+        amount_value: "25.00",
+        amount_currency: "EUR"
+      )
+
+      Subscription.record_from_mollie(mollie_sub)
+
+      assert_equal "default", existing.reload.name
+    end
+
+    test "record_from_mollie reads name from metadata for new records" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
+      mollie_sub = stub_mollie_subscription(
+        id:          "sub_from_webhook",
+        status:      "active",
+        customer_id: mollie_pay_customers(:acme).mollie_id,
+        interval:    "1 month",
+        amount_value: "30.00",
+        amount_currency: "EUR",
+        metadata:    { "mollie_pay_name" => "premium" }
+      )
+
+      subscription = Subscription.record_from_mollie(mollie_sub)
+
+      assert_equal "premium", subscription.name
+    end
+
+    test "record_from_mollie defaults name to 'default' without metadata" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
+      mollie_sub = stub_mollie_subscription(
+        id:          "sub_no_meta",
+        status:      "active",
+        customer_id: mollie_pay_customers(:acme).mollie_id,
+        interval:    "1 month",
+        amount_value: "20.00",
+        amount_currency: "EUR"
+      )
+
+      subscription = Subscription.record_from_mollie(mollie_sub)
+
+      assert_equal "default", subscription.name
+    end
+
     private
 
-      def stub_mollie_subscription(id:, status:, customer_id:, interval:, amount_value:, amount_currency:)
+      def stub_mollie_subscription(id:, status:, customer_id:, interval:, amount_value:, amount_currency:, metadata: nil)
         amount = OpenStruct.new(value: amount_value, currency: amount_currency)
         OpenStruct.new(
           id:          id,
           status:      status,
           customer_id: customer_id,
           interval:    interval,
-          amount:      amount
+          amount:      amount,
+          metadata:    metadata
         )
       end
   end


### PR DESCRIPTION
## Summary
- Add `name` column to subscriptions (default: `"default"`) enabling multiple concurrent subscriptions per customer
- All Billable subscription methods accept optional `name:` keyword — fully backward compatible
- Partial unique index on `[customer_id, name]` WHERE status IN ('pending', 'active') — database-level idempotency
- Race condition handling: cancel orphaned Mollie subscription on `RecordNotUnique`
- Name stored in Mollie metadata for webhook recovery

## Key decisions
- `presence: true` only (no format validation) — matches Pay gem pattern
- No-argument defaults to `name: "default"` — backward compatible
- `record_from_mollie` never overwrites existing name, reads from metadata for new records
- `ACTIVE_STATUSES` constant ties model to partial index condition

## Test plan
- [x] Create default subscription (backward compat)
- [x] Create named subscription with metadata
- [x] Idempotency guard scoped by name
- [x] Idempotency allows different names simultaneously
- [x] Cancel specific named subscription
- [x] Cancel raises for nonexistent name
- [x] `mollie_subscribed?` scoped by name
- [x] `mollie_subscription` scoped by name
- [x] `record_from_mollie` preserves existing name
- [x] `record_from_mollie` reads name from metadata
- [x] `record_from_mollie` defaults name without metadata
- [x] Name presence validation
- [x] Named scope filtering
- [x] All 122 tests pass, rubocop clean

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this is a library gem, not a deployed service.

Closes #18