### PR TITLE
feat(billable): Add Mollie API idempotency keys to all POST requests

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -56,7 +56,7 @@ module MolliePay
         metadata:    { mollie_pay_name: name }
       }
       params[:start_date] = start_date.to_s if start_date
-      ms = Mollie::Customer::Subscription.create(**params)
+      ms = Mollie::Customer::Subscription.create(**params, idempotency_key: SecureRandom.uuid)
       Subscription.create!(
         customer:  customer,
         mollie_id: ms.id,
@@ -85,8 +85,9 @@ module MolliePay
     def mollie_refund(payment, amount: nil)
       amount_cents = amount || payment.amount
       mr = Mollie::Refund.create(
-        paymentId: payment.mollie_id,
-        amount:    mollie_amount(amount_cents)
+        paymentId:      payment.mollie_id,
+        amount:         mollie_amount(amount_cents),
+        idempotency_key: SecureRandom.uuid
       )
       Refund.create!(
         payment:  payment,
@@ -146,14 +147,15 @@ module MolliePay
         raise MolliePay::ConfigurationError, "No redirect_url provided and default_redirect_path is not configured" if resolved_redirect_url.blank?
 
         mp = Mollie::Payment.create(
-          amount:       mollie_amount(amount),
-          description:  description,
-          redirectUrl:  resolved_redirect_url,
-          webhookUrl:   MolliePay.configuration.webhook_url,
-          customerId:   customer.mollie_id,
-          sequenceType: sequence_type,
-          method:       method,
-          metadata:     metadata
+          amount:          mollie_amount(amount),
+          description:     description,
+          redirectUrl:     resolved_redirect_url,
+          webhookUrl:      MolliePay.configuration.webhook_url,
+          customerId:      customer.mollie_id,
+          sequenceType:    sequence_type,
+          method:          method,
+          metadata:        metadata,
+          idempotency_key: SecureRandom.uuid
         )
 
         payment.update!(
@@ -168,8 +170,9 @@ module MolliePay
 
     def create_mollie_customer_on_mollie
       mc = Mollie::Customer.create(
-        name:  respond_to?(:name)  ? name  : nil,
-        email: respond_to?(:email) ? email : nil
+        name:            respond_to?(:name)  ? name  : nil,
+        email:           respond_to?(:email) ? email : nil,
+        idempotency_key: SecureRandom.uuid
       )
       create_mollie_customer!(mollie_id: mc.id)
     end

--- a/docs/plans/2026-03-17-005-feat-mollie-api-idempotency-keys-plan.md
+++ b/docs/plans/2026-03-17-005-feat-mollie-api-idempotency-keys-plan.md
@@ -1,0 +1,38 @@
+---
+title: "feat: Add Mollie API idempotency keys to all POST requests"
+type: feat
+status: active
+date: 2026-03-17
+---
+
+# feat: Add Mollie API idempotency keys to all POST requests
+
+## Overview
+
+Mollie supports idempotency keys via the `Idempotency-Key` HTTP header on POST
+requests. If a request fails due to network issues and is retried with the same
+key within 1 hour, Mollie returns the cached response instead of creating a
+duplicate resource. The mollie-api-ruby gem supports this natively via the
+`idempotency_key:` parameter on `.create()` calls.
+
+Source: https://docs.mollie.com/reference/api-idempotency
+
+## Proposed Solution
+
+Add `idempotency_key: SecureRandom.uuid` to all four Mollie API POST calls in
+`Billable`:
+
+1. `Mollie::Payment.create` (line 148)
+2. `Mollie::Customer.create` (line 170)
+3. `Mollie::Customer::Subscription.create` (line 59)
+4. `Mollie::Refund.create` (line 87)
+
+UUID4 is the recommended key format per Mollie docs. A random key per call is
+correct — idempotency protects against network-level retries, not business-level
+duplicates (which are handled by our existing idempotency guards).
+
+## Acceptance Criteria
+
+- [ ] All four Mollie POST calls include `idempotency_key: SecureRandom.uuid`
+- [ ] Tests verify idempotency keys are passed through
+- [ ] Documentation updated

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -512,6 +512,77 @@ module MolliePay
       end
     end
 
+    # === Idempotency keys ===
+
+    test "mollie_pay_once sends idempotency key to Mollie" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_idem_once")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_once(amount: 1000, description: "Test", redirect_url: "https://example.com/return")
+      end
+
+      assert received_args[:idempotency_key].present?, "idempotency_key should be present"
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
+    test "mollie_pay_first sends idempotency key to Mollie" do
+      received_args = nil
+      response = fake_mollie_payment(id: "tr_idem_first")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Payment.stub(:create, fake_create) do
+        @org.mollie_pay_first(amount: 1000, description: "Test", redirect_url: "https://example.com/return")
+      end
+
+      assert received_args[:idempotency_key].present?
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
+    test "mollie_subscribe sends idempotency key to Mollie" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "canceled", canceled_at: Time.current)
+
+      received_args = nil
+      response = fake_mollie_subscription(id: "sub_idem")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Customer::Subscription.stub(:create, fake_create) do
+        @org.mollie_subscribe(amount: 2500, interval: "1 month", description: "Test")
+      end
+
+      assert received_args[:idempotency_key].present?
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
+    test "mollie_refund sends idempotency key to Mollie" do
+      received_args = nil
+      response = fake_mollie_refund(id: "re_idem")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Refund.stub(:create, fake_create) do
+        @org.mollie_refund(mollie_pay_payments(:acme_oneoff))
+      end
+
+      assert received_args[:idempotency_key].present?
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
+    test "customer creation sends idempotency key to Mollie" do
+      org = Organization.create!(name: "Idem Org", email: "idem@org.nl")
+
+      received_args = nil
+      response = fake_mollie_customer(id: "cst_idem")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Customer.stub(:create, fake_create) do
+        org.mollie_customer!
+      end
+
+      assert received_args[:idempotency_key].present?
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
     test "on_mollie_* hooks are defined and callable" do
       payment      = mollie_pay_payments(:acme_first)
       subscription = mollie_pay_subscriptions(:acme_monthly)


### PR DESCRIPTION
## Summary
- Add `idempotency_key: SecureRandom.uuid` to all four Mollie API POST calls: Payment, Customer, Subscription, and Refund creation
- Protects against duplicate resource creation on network retries
- Uses the mollie-api-ruby gem's native `idempotency_key:` parameter — the gem extracts it and sends it as the `Idempotency-Key` HTTP header
- Mollie caches responses for 1 hour per key

Source: https://docs.mollie.com/reference/api-idempotency

## Testing
- 120 tests, 241 assertions, 0 failures, 0 rubocop offenses
- Existing stub-based tests continue to pass (stubs ignore unknown params)