### PR TITLE
feat(webhooks): Foundation & webhook infrastructure for full Mollie API support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ objects or interactors.
 ```
 POST /mollie_pay/webhooks
   → WebhooksController#create
-  → validates mollie_id format: (tr|sub|re)_[a-zA-Z0-9]+
+  → validates mollie_id format: (tr|sub|re|stl)_[a-zA-Z0-9]{1,64}
   → ProcessWebhookJob.perform_later(mollie_id)
   → head :ok
 

--- a/app/controllers/mollie_pay/webhooks_controller.rb
+++ b/app/controllers/mollie_pay/webhooks_controller.rb
@@ -1,6 +1,6 @@
 module MolliePay
   class WebhooksController < ApplicationController
-    MOLLIE_ID_FORMAT = /\A(tr|sub|re)_[a-zA-Z0-9]+\z/
+    MOLLIE_ID_FORMAT = /\A(tr|sub|re|stl)_[a-zA-Z0-9]{1,64}\z/
 
     skip_forgery_protection
 

--- a/app/jobs/mollie_pay/process_webhook_job.rb
+++ b/app/jobs/mollie_pay/process_webhook_job.rb
@@ -4,13 +4,15 @@ module MolliePay
 
     retry_on StandardError, wait: :polynomially_longer, attempts: 5
     discard_on Mollie::ResourceNotFoundError
-    discard_on ActiveRecord::RecordNotFound
 
     def perform(mollie_id)
       case mollie_id
       when /\Atr_/  then Payment.record_from_mollie(Mollie::Payment.get(mollie_id))
       when /\Asub_/ then sync_subscription(mollie_id)
       when /\Are_/  then sync_refund(mollie_id)
+      when /\Astl_/ then sync_settlement(mollie_id)
+      else
+        Rails.logger.warn("[MolliePay] Unknown webhook prefix for mollie_id: #{mollie_id}")
       end
     end
 
@@ -21,6 +23,8 @@ module MolliePay
         Subscription.record_from_mollie(
           Mollie::Subscription.get(mollie_id, customer_id: subscription.customer.mollie_id)
         )
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.info("[MolliePay] Discarding subscription webhook — local record not found: #{mollie_id}")
       end
 
       def sync_refund(mollie_id)
@@ -28,6 +32,13 @@ module MolliePay
         Refund.record_from_mollie(
           Mollie::Refund.get(mollie_id, payment_id: refund.payment.mollie_id)
         )
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.info("[MolliePay] Discarding refund webhook — local record not found: #{mollie_id}")
+      end
+
+      def sync_settlement(mollie_id)
+        settlement = Mollie::Settlement.get(mollie_id)
+        ActiveSupport::Notifications.instrument("mollie_pay.settlement_received", settlement: settlement)
       end
   end
 end

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -83,6 +83,7 @@ module MolliePay
     end
 
     def mollie_refund(payment, amount: nil)
+      verify_payment_ownership!(payment)
       amount_cents = amount || payment.amount
       mr = Mollie::Refund.create(
         paymentId: payment.mollie_id,
@@ -118,6 +119,7 @@ module MolliePay
     # === Hooks — override these in your model ===
 
     def on_mollie_payment_paid(payment)             ; end
+    def on_mollie_payment_authorized(payment)       ; end
     def on_mollie_payment_failed(payment)           ; end
     def on_mollie_payment_canceled(payment)         ; end
     def on_mollie_payment_expired(payment)          ; end
@@ -130,6 +132,10 @@ module MolliePay
     def on_mollie_refund_processed(refund)          ; end
 
     private
+
+    def verify_payment_ownership!(payment)
+      raise MolliePay::Error, "Payment does not belong to this customer" unless mollie_payments.exists?(id: payment.id)
+    end
 
     def create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type:)
       customer = mollie_customer!

--- a/app/models/mollie_pay/payment.rb
+++ b/app/models/mollie_pay/payment.rb
@@ -7,6 +7,9 @@ module MolliePay
     belongs_to :subscription, optional: true
     has_many   :refunds, dependent: :destroy
 
+    # amount_remaining uses nil-semantics: nil = "never fetched from Mollie",
+    # 0 = "fully captured/refunded". Only populated when Mollie includes the field.
+
     validates :mollie_id,     uniqueness: true, allow_nil: true
     validates :status,        inclusion: { in: STATUSES }
     validates :sequence_type, inclusion: { in: SEQUENCE_TYPES }
@@ -32,15 +35,20 @@ module MolliePay
       end
 
       payment.update!(
-        customer:      customer,
-        status:        mp.status,
-        amount:        mollie_value_to_cents(mp.amount),
-        currency:      mp.amount.currency,
-        sequence_type: mp.sequence_type.presence || "oneoff",
-        paid_at:       mp.status == "paid" && !payment.paid_at ? Time.current : payment.paid_at,
-        failed_at:     mp.status == "failed" && !payment.failed_at ? Time.current : payment.failed_at,
-        canceled_at:   mp.status == "canceled" && !payment.canceled_at ? Time.current : payment.canceled_at,
-        expired_at:    mp.status == "expired" && !payment.expired_at ? Time.current : payment.expired_at
+        customer:            customer,
+        status:              mp.status,
+        amount:              mollie_value_to_cents(mp.amount),
+        currency:            mp.amount.currency,
+        sequence_type:       mp.sequence_type.presence || "oneoff",
+        paid_at:             mp.status == "paid" && !payment.paid_at ? Time.current : payment.paid_at,
+        authorized_at:       mp.status == "authorized" && !payment.authorized_at ? Time.current : payment.authorized_at,
+        failed_at:           mp.status == "failed" && !payment.failed_at ? Time.current : payment.failed_at,
+        canceled_at:         mp.status == "canceled" && !payment.canceled_at ? Time.current : payment.canceled_at,
+        expired_at:          mp.status == "expired" && !payment.expired_at ? Time.current : payment.expired_at,
+        amount_refunded:     mp.amount_refunded ? mollie_value_to_cents(mp.amount_refunded) : payment.amount_refunded,
+        amount_remaining:    mp.amount_remaining ? mollie_value_to_cents(mp.amount_remaining) : payment.amount_remaining,
+        amount_captured:     mp.amount_captured ? mollie_value_to_cents(mp.amount_captured) : payment.amount_captured,
+        amount_charged_back: mp.amount_charged_back ? mollie_value_to_cents(mp.amount_charged_back) : payment.amount_charged_back
       )
 
       payment.notify_billable(mp) if payment.status != previous_status
@@ -62,9 +70,10 @@ module MolliePay
         else
           billable.on_mollie_payment_paid(self)
         end
-      when "failed"   then billable.on_mollie_payment_failed(self)
-      when "canceled" then billable.on_mollie_payment_canceled(self)
-      when "expired"  then billable.on_mollie_payment_expired(self)
+      when "authorized" then billable.on_mollie_payment_authorized(self)
+      when "failed"     then billable.on_mollie_payment_failed(self)
+      when "canceled"   then billable.on_mollie_payment_canceled(self)
+      when "expired"    then billable.on_mollie_payment_expired(self)
       end
     end
 

--- a/db/migrate/20260317194500_add_authorized_at_to_mollie_pay_payments.rb
+++ b/db/migrate/20260317194500_add_authorized_at_to_mollie_pay_payments.rb
@@ -1,0 +1,5 @@
+class AddAuthorizedAtToMolliePayPayments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :mollie_pay_payments, :authorized_at, :datetime
+  end
+end

--- a/db/migrate/20260317194501_add_amount_tracking_to_mollie_pay_payments.rb
+++ b/db/migrate/20260317194501_add_amount_tracking_to_mollie_pay_payments.rb
@@ -1,0 +1,8 @@
+class AddAmountTrackingToMolliePayPayments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :mollie_pay_payments, :amount_refunded, :integer, default: 0
+    add_column :mollie_pay_payments, :amount_remaining, :integer
+    add_column :mollie_pay_payments, :amount_captured, :integer, default: 0
+    add_column :mollie_pay_payments, :amount_charged_back, :integer, default: 0
+  end
+end

--- a/docs/mollie-api-full-coverage-findings.md
+++ b/docs/mollie-api-full-coverage-findings.md
@@ -1,0 +1,372 @@
+# Mollie API Full Coverage — Research Findings
+
+> Research conducted 2026-03-17 for MolliePay v0.4.0
+> Source: https://docs.mollie.com/reference/overview
+
+---
+
+## Complete Mollie API Surface
+
+### Accepting Payments
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create payment | POST | `/payments` | Core endpoint. Supports oneoff, first, recurring |
+| List payments | GET | `/payments` | Paginated |
+| Get payment | GET | `/payments/{id}` | Includes amount tracking fields |
+| Update payment | PATCH | `/payments/{id}` | Only open/pending payments |
+| Cancel payment | DELETE | `/payments/{id}` | Only authorized payments |
+| Release authorization | POST | `/payments/{id}/authorizations/release` | Release held funds |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| List methods | GET | `/methods` | Enabled methods for current profile |
+| List all methods | GET | `/methods?includeWallets=true` | All available methods |
+| Get method | GET | `/methods/{id}` | Single method details |
+| Enable method | POST | `/profiles/{id}/methods/{method}` | Connect only |
+| Disable method | DELETE | `/profiles/{id}/methods/{method}` | Connect only |
+| Enable issuer | POST | `/profiles/{id}/methods/{method}/issuers/{issuerId}` | Connect only |
+| Disable issuer | DELETE | `/profiles/{id}/methods/{method}/issuers/{issuerId}` | Connect only |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create refund | POST | `/payments/{paymentId}/refunds` | ✅ Supported |
+| List payment refunds | GET | `/payments/{paymentId}/refunds` | Not yet supported |
+| Get refund | GET | `/payments/{paymentId}/refunds/{id}` | ✅ Supported |
+| Cancel refund | DELETE | `/payments/{paymentId}/refunds/{id}` | Not yet supported |
+| List all refunds | GET | `/refunds` | Not yet supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| List payment chargebacks | GET | `/payments/{paymentId}/chargebacks` | Not supported |
+| Get chargeback | GET | `/payments/{paymentId}/chargebacks/{id}` | Not supported |
+| List all chargebacks | GET | `/chargebacks` | Not supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create capture | POST | `/payments/{paymentId}/captures` | Not supported |
+| List captures | GET | `/payments/{paymentId}/captures` | Not supported |
+| Get capture | GET | `/payments/{paymentId}/captures/{id}` | Not supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Apple Pay session | POST | `/wallets/applepay/sessions` | Not supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create payment link | POST | `/payment-links` | Not supported |
+| List payment links | GET | `/payment-links` | Not supported |
+| Get payment link | GET | `/payment-links/{id}` | Not supported |
+| Update payment link | PATCH | `/payment-links/{id}` | Not supported |
+| Delete payment link | DELETE | `/payment-links/{id}` | Not supported |
+| Get link payments | GET | `/payment-links/{id}/payments` | Not supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| List terminals | GET | `/terminals` | POS devices |
+| Get terminal | GET | `/terminals/{id}` | POS devices |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create route | POST | `/payments/{paymentId}/routes` | Delayed routing (Connect) |
+| List routes | GET | `/payments/{paymentId}/routes` | Delayed routing (Connect) |
+| Get route | GET | `/payments/{paymentId}/routes/{id}` | Delayed routing (Connect) |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create session | POST | `/sessions` | Beta feature |
+| Get session | GET | `/sessions/{id}` | Beta feature |
+
+### Receiving Orders
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create order | POST | `/orders` | E-commerce orders with lines |
+| List orders | GET | `/orders` | Paginated |
+| Get order | GET | `/orders/{id}` | Includes lines and embedded payments |
+| Update order | PATCH | `/orders/{id}` | Addresses and metadata |
+| Cancel order | DELETE | `/orders/{id}` | Cancel entire order |
+| Manage lines | PATCH | `/orders/{id}/lines` | Batch line operations |
+| Cancel lines | DELETE | `/orders/{id}/lines` | Cancel specific lines |
+| Update line | PATCH | `/orders/{id}/lines/{lineId}` | Single line update |
+| Create order payment | POST | `/orders/{id}/payments` | Retry payment for order |
+| Create order refund | POST | `/orders/{id}/refunds` | Line-based refund |
+| List order refunds | GET | `/orders/{id}/refunds` | Order-scoped refunds |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create shipment | POST | `/orders/{orderId}/shipments` | Triggers capture |
+| List shipments | GET | `/orders/{orderId}/shipments` | |
+| Get shipment | GET | `/orders/{orderId}/shipments/{id}` | |
+| Update shipment | PATCH | `/orders/{orderId}/shipments/{id}` | Tracking info |
+
+### Recurring
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create customer | POST | `/customers` | ✅ Supported |
+| List customers | GET | `/customers` | Not yet supported |
+| Get customer | GET | `/customers/{id}` | ✅ Supported |
+| Update customer | PATCH | `/customers/{id}` | Not yet supported |
+| Delete customer | DELETE | `/customers/{id}` | Not yet supported |
+| Create customer payment | POST | `/customers/{id}/payments` | ✅ Via Billable |
+| List customer payments | GET | `/customers/{id}/payments` | Not yet supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create mandate | POST | `/customers/{customerId}/mandates` | Auto via first payment |
+| List mandates | GET | `/customers/{customerId}/mandates` | Not yet supported |
+| Get mandate | GET | `/customers/{customerId}/mandates/{id}` | ✅ Supported |
+| Revoke mandate | DELETE | `/customers/{customerId}/mandates/{id}` | Not yet supported |
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create subscription | POST | `/customers/{customerId}/subscriptions` | ✅ Supported |
+| List subscriptions | GET | `/customers/{customerId}/subscriptions` | Not yet supported |
+| Get subscription | GET | `/customers/{customerId}/subscriptions/{id}` | ✅ Supported |
+| Update subscription | PATCH | `/customers/{customerId}/subscriptions/{id}` | Not yet supported |
+| Cancel subscription | DELETE | `/customers/{customerId}/subscriptions/{id}` | ✅ Supported |
+| List all subscriptions | GET | `/subscriptions` | Not yet supported |
+| List sub payments | GET | `/customers/{cId}/subscriptions/{sId}/payments` | Not yet supported |
+
+### Mollie Connect (OAuth)
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Generate tokens | POST | `/oauth2/tokens` | OAuth flow |
+| Revoke tokens | DELETE | `/oauth2/tokens` | OAuth flow |
+| List permissions | GET | `/permissions` | OAuth scope check |
+| Get permission | GET | `/permissions/{id}` | OAuth scope check |
+| Get organization | GET | `/organizations/{id}` | Account info |
+| Get current org | GET | `/organizations/me` | Account info |
+| Get partner status | GET | `/organizations/{id}/partner-status` | Partner info |
+| Create profile | POST | `/profiles` | Multi-profile management |
+| List profiles | GET | `/profiles` | |
+| Get profile | GET | `/profiles/{id}` | |
+| Update profile | PATCH | `/profiles/{id}` | |
+| Delete profile | DELETE | `/profiles/{id}` | |
+| Get current profile | GET | `/profiles/me` | |
+| Get onboarding status | GET | `/onboarding/v1/status` | Partner onboarding |
+| Submit onboarding | POST | `/onboarding/v1/submit-data` | Partner onboarding |
+| List capabilities | GET | `/capabilities` | Account capabilities |
+| List clients | GET | `/clients` | Partner clients |
+| Get client | GET | `/clients/{id}` | Partner clients |
+| Create client link | POST | `/client-links` | Partner onboarding |
+| Create balance transfer | POST | `/balance-transfers` | Platform payouts |
+| List transfers | GET | `/balance-transfers` | |
+| Get transfer | GET | `/balance-transfers/{id}` | |
+
+### Business Operations
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| List balances | GET | `/balances` | Account balances |
+| Get balance | GET | `/balances/{id}` | |
+| Get primary balance | GET | `/balances/primary` | |
+| Get balance report | GET | `/balances/{id}/report` | Detailed report |
+| List transactions | GET | `/balances/{id}/transactions` | Balance movements |
+| List settlements | GET | `/settlements` | Bank payouts |
+| Get settlement | GET | `/settlements/{id}` | |
+| Get open settlement | GET | `/settlements/open` | Current accumulating |
+| Get next settlement | GET | `/settlements/next` | Upcoming payout |
+| Settlement payments | GET | `/settlements/{id}/payments` | Included payments |
+| Settlement captures | GET | `/settlements/{id}/captures` | Included captures |
+| Settlement refunds | GET | `/settlements/{id}/refunds` | Included refunds |
+| Settlement chargebacks | GET | `/settlements/{id}/chargebacks` | Included chargebacks |
+| List invoices | GET | `/invoices` | Mollie billing invoices |
+| Get invoice | GET | `/invoices/{id}` | |
+
+### Revenue Collection
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create sales invoice | POST | `/sales-invoices` | Issue invoices to customers |
+| List sales invoices | GET | `/sales-invoices` | |
+| Get sales invoice | GET | `/sales-invoices/{id}` | |
+| Update sales invoice | PATCH | `/sales-invoices/{id}` | |
+| Delete sales invoice | DELETE | `/sales-invoices/{id}` | |
+
+### Webhooks Management
+
+| Endpoint | Method | Path | Notes |
+|---|---|---|---|
+| Create webhook | POST | `/webhooks` | Register webhook URLs |
+| List webhooks | GET | `/webhooks` | |
+| Get webhook | GET | `/webhooks/{id}` | |
+| Update webhook | PATCH | `/webhooks/{id}` | |
+| Delete webhook | DELETE | `/webhooks/{id}` | |
+| Test webhook | POST | `/webhooks/{id}/tests` | |
+| Get webhook event | GET | `/webhook-events/{id}` | |
+
+---
+
+## Coverage Gap Analysis
+
+### Currently Supported (v0.4.0)
+
+**Full support:** Customers (create/get), Payments (create oneoff/first/recurring, get), Subscriptions (create/cancel/get), Mandates (get), Refunds (create/get), Webhook handling (tr_/sub_/re_)
+
+### Not Yet Supported
+
+**Total Mollie API endpoints:** ~120+
+**Currently supported operations:** ~15
+**Coverage:** ~12%
+
+### Categorized by Priority
+
+**P0 — Critical for any SaaS app:**
+- Payment Methods listing (every checkout needs this)
+- Chargebacks (financial risk without it)
+- Payment `authorized` state + captures (Klarna/BNPL)
+- Payment update and cancel
+
+**P1 — High value:**
+- Payment Links (invoicing use case)
+- Refund cancel, list operations
+- Customer update/delete
+- Subscription update, list operations
+- Mandate list, revoke
+
+**P2 — E-commerce:**
+- Orders API (full CRUD)
+- Order Lines management
+- Shipments
+- Order refunds
+
+**P3 — Business operations:**
+- Settlements (reconciliation)
+- Balances (treasury)
+- Invoices (billing)
+- Sales Invoices (revenue collection)
+
+**P4 — Platform/Admin:**
+- Profiles
+- Organizations
+- Terminals
+- Apple Pay sessions
+
+**P5 — Mollie Connect (deferred):**
+- OAuth token management
+- Permissions
+- Onboarding
+- Client Links
+- Capabilities
+- Balance Transfers
+
+---
+
+## Key Architecture Findings
+
+### 1. Webhook ID Prefix Gap (Critical)
+
+The current `MOLLIE_ID_FORMAT` regex `/\A(tr|sub|re)_[a-zA-Z0-9]+\z/` silently rejects all new resource type webhooks. Mollie ID prefixes discovered:
+
+| Prefix | Resource | Sends Webhooks? |
+|---|---|---|
+| `tr_` | Payment | ✅ Yes |
+| `sub_` | Subscription | ✅ Yes |
+| `re_` | Refund | ✅ Yes |
+| `ord_` | Order | ✅ Yes |
+| `stl_` | Settlement | ✅ Yes |
+| `pl_` | Payment Link | ❌ No (via `tr_`) |
+| `chb_` | Chargeback | ❌ No (via `tr_`) |
+| `cpt_` | Capture | ❌ No (synchronous) |
+| `shp_` | Shipment | ❌ No (via `ord_`) |
+| `bal_` | Balance | ❌ No |
+| `inv_` | Invoice | ❌ No |
+
+### 2. Chargebacks Are Invisible (Critical)
+
+Chargebacks don't trigger separate webhooks. They arrive embedded in payment objects via `tr_` webhooks. The payment status stays "paid" — only `amountChargedBack` changes. Current `previous_status` check will never detect them.
+
+### 3. Captures Are Synchronous
+
+Mollie does not send webhooks for captures. Captures are created via API call and the payment status eventually changes to "paid" via a subsequent `tr_` webhook. No separate model needed — just a Billable method.
+
+### 4. Payment Links Break Customer Assumption
+
+Payment links can be created without a customer. When paid, the resulting payment has no `customer_id`. Current `Payment.record_from_mollie` requires a customer — payments from anonymous payment links will be discarded.
+
+### 5. Orders Are a Different Domain
+
+Orders involve lines, shipments, addresses, and a different lifecycle. They need a separate `Orderable` concern rather than overloading `Billable`.
+
+### 6. Settlements Are Account-Level
+
+Settlements have no customer association. They need a different notification mechanism — `ActiveSupport::Notifications` or a configurable callback.
+
+### 7. Mollie Connect Is Architecturally Invasive
+
+OAuth multi-tenant changes every API call from using the global `Mollie::Client` to per-request token passing. Must be designed as a separate effort.
+
+---
+
+## Mollie SDK Coverage (mollie-api-ruby v4.19.0+)
+
+The `mollie-api-ruby` gem provides Ruby SDK classes for most API resources:
+
+| SDK Class | MolliePay Model |
+|---|---|
+| `Mollie::Payment` | `MolliePay::Payment` ✅ |
+| `Mollie::Customer` | `MolliePay::Customer` ✅ |
+| `Mollie::Customer::Subscription` | `MolliePay::Subscription` ✅ |
+| `Mollie::Customer::Mandate` | `MolliePay::Mandate` ✅ |
+| `Mollie::Refund` | `MolliePay::Refund` ✅ |
+| `Mollie::Method` | Not yet modeled |
+| `Mollie::Payment::Chargeback` | Not yet modeled |
+| `Mollie::Payment::Capture` | Not needed (sync operation) |
+| `Mollie::PaymentLink` | Not yet modeled |
+| `Mollie::Order` | Not yet modeled |
+| `Mollie::Order::Line` | Not yet modeled |
+| `Mollie::Order::Shipment` | Not yet modeled |
+| `Mollie::Settlement` | Not yet modeled |
+| `Mollie::Balance` | Not yet modeled |
+| `Mollie::Invoice` | Not yet modeled |
+| `Mollie::Profile` | Not yet modeled |
+| `Mollie::Organization` | Not yet modeled |
+| `Mollie::Terminal` | Not yet modeled |
+
+---
+
+## Payment Status Lifecycle
+
+```
+open → paid
+open → canceled
+open → expired
+open → failed
+open → authorized → paid (via capture)
+authorized → canceled (via release)
+```
+
+Payment amount fields:
+- `amount` — original payment amount
+- `amountRefunded` — total refunded
+- `amountRemaining` — amount minus refunds
+- `amountCaptured` — total captured (for authorized payments)
+- `amountChargedBack` — total charged back
+
+---
+
+## Order Status Lifecycle
+
+```
+created → paid
+created → authorized → paid (via shipment/capture)
+created → canceled
+created → expired
+paid → shipping → completed
+authorized → shipping → completed
+any → canceled (partial cancel of lines possible)
+```
+
+---
+
+## Recommendations
+
+1. **Start with Phase 1 (Foundation)** — webhook infrastructure and authorized state. Everything else depends on this.
+2. **Phase 2 (Chargebacks + Captures)** delivers the highest business value with moderate effort.
+3. **Phase 3 (Payment Links)** enables invoicing workflows — a top SaaS use case.
+4. **Phase 4 (Orders)** is the largest effort and serves e-commerce more than SaaS. Consider deferring.
+5. **Phase 5 (Read-only)** is low effort, high completeness.
+6. **Phase 6 (Connect)** is a separate project. Do not start it as part of this work.

--- a/docs/plans/2026-03-17-004-feat-full-mollie-api-support-plan.md
+++ b/docs/plans/2026-03-17-004-feat-full-mollie-api-support-plan.md
@@ -1,0 +1,521 @@
+---
+title: "feat: Full Mollie API Support for MolliePay"
+type: feat
+status: active
+date: 2026-03-17
+---
+
+# Full Mollie API Support for MolliePay
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-17
+**Review agents used:** Architecture Strategist, DHH Rails Reviewer, Kieran Rails Reviewer, Data Integrity Guardian, Security Sentinel, Performance Oracle, Code Simplicity Reviewer, Pattern Recognition Specialist, Best Practices Researcher, Framework Docs Researcher
+
+### Key Changes from Review
+
+1. **Phase 4 (Orders) removed** — e-commerce domain, not SaaS. If needed later, design as separate engine or major version.
+2. **Phase 5 read-only wrappers removed** — zero value over direct `mollie-api-ruby` use. Document SDK usage instead.
+3. **Payment Methods wrapper removed** — same rationale. Use `Mollie::Method.all` directly.
+4. **`customer_id` nullable approach redesigned** — keep NOT NULL constraint; payment link payments route through PaymentLink for notification, not Billable.
+5. **Chargeback detection extracted** into separate `SyncChargebacksJob` to keep `record_from_mollie` fast.
+6. **Settlement model replaced** with `ActiveSupport::Notifications`-only approach (no AR model).
+7. **Webhook regex** changed from fully permissive to extensible allowlist with length cap.
+8. **`discard_on RecordNotFound`** refactored to be branch-specific instead of blanket.
+9. **Ownership verification** added to all Billable methods that accept a payment argument.
+10. **Payment link API** simplified to class method only (no dual Billable + class method).
+
+---
+
+## Overview
+
+Expand MolliePay from its current 5-resource coverage (Customers, Payments, Subscriptions, Mandates, Refunds) to complete SaaS payment lifecycle support. The target: headless, simple, complete. The engine adds 2 new models (Chargeback, PaymentLink), core payment operations (captures, updates, cancellations), and settlement notifications — keeping the codebase at ~1200-1400 LOC.
+
+**Explicitly out of scope:** Orders API (e-commerce domain), read-only API wrappers (use `mollie-api-ruby` directly), Mollie Connect/OAuth (separate plan when needed).
+
+## Current State (v0.4.0)
+
+| Resource | Status | Operations |
+|---|---|---|
+| Customers | ✅ | create, get |
+| Payments | ✅ | create (oneoff/first/recurring), get |
+| Subscriptions | ✅ | create, cancel, get |
+| Mandates | ✅ | get (auto-created via first payment) |
+| Refunds | ✅ | create, get |
+| Webhooks | ✅ | tr_, sub_, re_ prefixes |
+
+## Target State
+
+Complete SaaS payment lifecycle across 4 implementation phases.
+
+---
+
+## Phase 1: Foundation & Webhook Infrastructure
+
+**Why first:** Every subsequent phase depends on extensible webhook routing, the `authorized` payment state, and accurate amount tracking. This is the foundation that unblocks everything else.
+
+### 1.1 Extend Webhook ID Prefix Routing
+
+**Problem:** The current `MOLLIE_ID_FORMAT` regex `/\A(tr|sub|re)_[a-zA-Z0-9]+\z/` silently rejects all new resource types. Settlement webhooks (`stl_`) will be dropped with a 422 — silent data loss.
+
+**Solution:**
+- Change regex to an extensible allowlist: `/\A(tr|sub|re|stl)_[a-zA-Z0-9]{1,64}\z/`
+- Add length cap (64 chars) to prevent queue abuse from extremely long strings
+- Add routing for `stl_` prefix in `ProcessWebhookJob#perform`
+- Add `else` clause that logs unknown prefixes via `Rails.logger.warn` (not silently dropped)
+- Refactor `discard_on ActiveRecord::RecordNotFound` to be branch-specific (rescue in `sync_subscription` and `sync_refund` only, not blanket)
+
+**Research Insights:**
+- **Security:** A fully permissive regex (`/\A[a-z]{2,4}_/`) opens job queue saturation attacks. An attacker can POST arbitrary IDs that pass validation, each enqueuing a job. The allowlist keeps the controller as a strict gatekeeper.
+- **Future-proofing:** New prefixes are added by updating the regex when adding support. This is a one-line change.
+- **`discard_on` refactor is critical:** The blanket `discard_on RecordNotFound` will silently lose payment link payments (Phase 3) where `Customer.find_by!` fails on nil `customer_id`. Must be branch-specific before Phase 3 ships.
+
+**Files:**
+- `app/controllers/mollie_pay/webhooks_controller.rb`
+- `app/jobs/mollie_pay/process_webhook_job.rb`
+- `test/controllers/mollie_pay/webhooks_controller_test.rb`
+- `test/jobs/mollie_pay/process_webhook_job_test.rb`
+
+### 1.2 Payment `authorized` State Support
+
+**Problem:** The `authorized` status exists in `Payment::STATUSES` but has no `authorized_at` timestamp, no hook, and no capture workflow. Klarna and other authorize-then-capture methods are unusable.
+
+**Solution:**
+- Add `authorized_at` column to `mollie_pay_payments`
+- Add `on_mollie_payment_authorized` hook to Billable
+- Set `authorized_at` in `Payment.record_from_mollie` on first observation
+- Update `notify_billable` to fire the new hook
+
+**Migration:**
+```ruby
+add_column :mollie_pay_payments, :authorized_at, :datetime
+```
+
+**Files:**
+- `db/migrate/XXXXXX_add_authorized_at_to_mollie_pay_payments.rb`
+- `app/models/mollie_pay/payment.rb`
+- `app/models/mollie_pay/billable.rb`
+- `test/models/mollie_pay/payment_test.rb`
+- `test/models/mollie_pay/billable_test.rb`
+
+### 1.3 Payment Amount Tracking Columns
+
+**Problem:** Mollie provides `amountRefunded`, `amountRemaining`, `amountCaptured`, `amountChargedBack` on every payment object. Currently none are stored locally, requiring API calls for basic state checks.
+
+**Solution:**
+- Add `amount_refunded`, `amount_remaining`, `amount_captured`, `amount_charged_back` columns (all integer cents)
+- Update `Payment.record_from_mollie` to populate them
+
+**Migration:**
+```ruby
+add_column :mollie_pay_payments, :amount_refunded, :integer, default: 0
+add_column :mollie_pay_payments, :amount_remaining, :integer
+add_column :mollie_pay_payments, :amount_captured, :integer, default: 0
+add_column :mollie_pay_payments, :amount_charged_back, :integer, default: 0
+```
+
+**Research Insights:**
+- **`amount_remaining` uses nil-semantics intentionally.** `nil` = "never fetched from Mollie", `0` = "fully captured/refunded". This distinction matters for existing records that predate the column. Document on the model with a comment.
+- **Handle absent API fields:** When `amountRemaining` is absent from Mollie's response (only present on certain statuses), leave the column nil rather than computing it. This keeps the data authoritative (from Mollie) rather than derived.
+- **No indexes needed.** These are write-heavy, read-light tracking columns. Adding indexes would slow webhook processing with no query benefit.
+
+**Files:**
+- `db/migrate/XXXXXX_add_amount_tracking_to_mollie_pay_payments.rb`
+- `app/models/mollie_pay/payment.rb`
+- `test/models/mollie_pay/payment_test.rb`
+
+### 1.4 Ownership Verification on Billable Methods
+
+**Problem (Security):** All Billable methods that accept a `payment` argument (`mollie_refund`, and upcoming `mollie_capture`, `mollie_cancel_payment`, etc.) do not verify the payment belongs to the calling billable's customer. An attacker who controls one billable could pass another's payment.
+
+**Solution:**
+- Add ownership verification to the existing `mollie_refund` method
+- Apply the same pattern to all new Billable methods in Phase 2
+- Pattern: `raise MolliePay::Error, "payment does not belong to this customer" unless mollie_payments.exists?(id: payment.id)`
+
+**Files:**
+- `app/models/mollie_pay/billable.rb`
+- `test/models/mollie_pay/billable_test.rb`
+
+**Acceptance Criteria:**
+- [x] Webhook regex uses extensible allowlist with length cap (64 chars)
+- [x] Unknown webhook prefixes logged via `Rails.logger.warn`, not silently dropped
+- [x] `ProcessWebhookJob` routes `stl_` prefix (initially to `ActiveSupport::Notifications`)
+- [x] `discard_on RecordNotFound` is branch-specific, not blanket
+- [x] `authorized_at` column exists and is set on first authorized observation
+- [x] `on_mollie_payment_authorized` hook fires on Billable owner
+- [x] Amount tracking columns populated from Mollie payment object
+- [x] Ownership verification on `mollie_refund` and all future Billable methods
+- [x] All existing tests pass unchanged
+
+---
+
+## Phase 2: Chargebacks, Captures & Payment Operations
+
+**Why second:** These are the highest-value additions for SaaS apps. Chargebacks are the most urgent financial event. Captures enable Klarna/BNPL flows. Payment updates/cancellation complete the payment lifecycle.
+
+### 2.1 Chargebacks Model
+
+**Critical insight:** Mollie does NOT send separate chargeback webhooks. Chargebacks arrive embedded in the payment object via the `tr_` webhook. The payment status stays "paid" — only `amountChargedBack` changes. The current `previous_status` guard will never detect chargebacks.
+
+**Solution:**
+- New `MolliePay::Chargeback` model (`chb_` prefix IDs)
+- `belongs_to :payment`, `has_many :chargebacks, dependent: :destroy` on Payment
+- Detect chargebacks in `Payment.record_from_mollie` by comparing `amount_charged_back` before and after the `update!`
+- When new chargeback amount detected, enqueue `SyncChargebacksJob` (separate from the payment update)
+- `SyncChargebacksJob` fetches chargebacks from Mollie API via `Mollie::Payment::Chargeback.all(payment_id:)`, upserts local records, fires hooks
+- Fire `on_mollie_chargeback_received(chargeback)` on Billable owner
+
+**Schema:**
+```ruby
+create_table :mollie_pay_chargebacks do |t|
+  t.string :mollie_id, null: false, index: { unique: true }
+  t.references :payment, null: false, foreign_key: { to_table: :mollie_pay_payments }
+  t.integer :amount, null: false
+  t.string :currency, null: false, default: "EUR"
+  t.json :reason   # Mollie returns a structured reason object
+  t.datetime :mollie_created_at
+  t.datetime :reversed_at
+  t.timestamps
+end
+```
+
+**Research Insights:**
+- **Extract chargeback sync into a separate job.** The current `record_from_mollie` is a fast, single-record upsert (one DB write). Adding a synchronous Mollie API call + N chargeback upserts breaks this contract. A separate `SyncChargebacksJob` keeps `record_from_mollie` fast and lets chargeback syncing retry independently if the chargebacks endpoint fails.
+- **Idempotency:** Use `find_or_initialize_by(mollie_id:)` with `RecordNotUnique` rescue, matching existing Subscription/Payment/Refund pattern.
+- **`reason` as JSON, not string.** Mollie's chargeback reason is a structured object, not a plain string.
+- **`currency` default.** Add `default: "EUR"` to match all existing table conventions.
+- **Rename `created_at_mollie` to `mollie_created_at`.** The `mollie_` prefix is the established convention for Mollie-sourced attributes.
+- **Detection pattern:**
+  ```ruby
+  # In Payment.record_from_mollie, after update!:
+  previous_charged_back = record.amount_charged_back_before_last_save || 0
+  if record.amount_charged_back > previous_charged_back
+    SyncChargebacksJob.perform_later(record.id)
+  end
+  ```
+
+**Files:**
+- `db/migrate/XXXXXX_create_mollie_pay_chargebacks.rb`
+- `app/models/mollie_pay/chargeback.rb`
+- `app/models/mollie_pay/payment.rb` (extend `record_from_mollie` detection)
+- `app/models/mollie_pay/billable.rb` (add hook)
+- `app/jobs/mollie_pay/sync_chargebacks_job.rb`
+- `test/models/mollie_pay/chargeback_test.rb`
+- `test/models/mollie_pay/payment_test.rb`
+- `test/models/mollie_pay/billable_test.rb`
+- `test/jobs/mollie_pay/sync_chargebacks_job_test.rb`
+- `lib/mollie_pay/test_fixtures/chargeback.json`
+
+### 2.2 Captures
+
+**Context:** Captures are synchronous — Mollie does NOT send webhooks for them. When a capture is created, the payment eventually transitions to "paid" via a `tr_` webhook. The SDK supports `Mollie::Payment::Capture.create(payment_id:, amount:)` via inherited `Base.create`.
+
+**Solution:**
+- Add `mollie_capture(payment, amount: nil)` to Billable
+- Capture calls `Mollie::Payment::Capture.create(payment_id: payment.mollie_id, amount: mollie_amount)` directly
+- If `amount` is nil, capture the full authorized amount
+- Raise `MolliePay::CaptureNotAllowed` if payment is not in `authorized` status
+- Add ownership verification: `raise ... unless mollie_payments.exists?(id: payment.id)`
+
+**Research Insights:**
+- **Keep on Billable, not Payment.** The existing pattern is all outbound API calls go through Billable (`mollie_refund`, `mollie_pay_once`, etc.). Consistency beats local elegance.
+- **Race condition:** Two concurrent `mollie_capture` calls could both see `status == "authorized"`. Mollie's API will reject the second, but add a guard: check status locally before calling the API. For extra safety, consider `with_lock` on the payment row.
+
+**Files:**
+- `app/models/mollie_pay/billable.rb`
+- `lib/mollie_pay/errors.rb` (add `CaptureNotAllowed`)
+- `test/models/mollie_pay/billable_test.rb`
+
+### 2.3 Payment Update & Cancel
+
+**Solution:**
+- Add `mollie_update_payment(payment, description: nil, redirect_url: nil, webhook_url: nil, metadata: nil)` to Billable
+- Add `mollie_cancel_payment(payment)` to Billable
+- Cancel raises `MolliePay::PaymentNotCancelable` if payment is not in a cancelable status
+- Update works only on open/pending payments
+- Both methods include ownership verification
+
+**Files:**
+- `app/models/mollie_pay/billable.rb`
+- `lib/mollie_pay/errors.rb` (add `PaymentNotCancelable`)
+- `test/models/mollie_pay/billable_test.rb`
+
+**Acceptance Criteria:**
+- [ ] Chargebacks detected from payment webhook via `amount_charged_back` comparison
+- [ ] `SyncChargebacksJob` fetches and upserts chargebacks independently
+- [ ] `on_mollie_chargeback_received(chargeback)` fires on Billable
+- [ ] Chargeback model with mollie_id (unique), amount, currency (default EUR), reason (JSON)
+- [ ] Chargeback upsert uses `find_or_initialize_by` + `RecordNotUnique` rescue
+- [ ] `mollie_capture(payment)` creates capture via Mollie API with ownership check
+- [ ] `CaptureNotAllowed` raised for non-authorized payments
+- [ ] `mollie_update_payment` updates open/pending payments with ownership check
+- [ ] `mollie_cancel_payment` cancels cancelable payments with ownership check
+- [ ] `PaymentNotCancelable` raised for non-cancelable payments
+
+---
+
+## Phase 3: Payment Links
+
+**Why third:** Payment links are one of Mollie's most-used features for invoicing. They don't require a customer, enabling a different use pattern than regular payments.
+
+### 3.1 Payment Links Model
+
+**Architecture decision (revised from review):** Payment links can be created without a customer (anonymous invoicing). However, **`customer_id` on payments stays NOT NULL.** Instead:
+
+- Customer-linked payment links: the resulting payment gets a `customer_id` normally
+- Anonymous payment links: the resulting payment is created WITHOUT going through `Payment.record_from_mollie`. Instead, `PaymentLink.record_payment_from_mollie` handles anonymous payments directly, persisting them on the PaymentLink via `payment_link_id`
+- `notify_billable` is skipped for customer-less payments; instead `on_mollie_payment_link_paid` fires on the PaymentLink itself (using `ActiveSupport::Notifications`)
+
+**Research Insights:**
+- **Do NOT make `customer_id` nullable.** Multiple reviewers flagged this as the highest-risk change. `Payment.record_from_mollie`, `Refund.record_from_mollie`, `notify_billable`, and all `has_many :through` associations assume non-null. The blast radius is too large.
+- **Alternative design:** Payment link payments with a customer work exactly like normal payments (the Mollie payment object has `customerId`). Anonymous payment link payments are a new code path in `ProcessWebhookJob` — when the fetched payment has no `customerId`, look for a matching PaymentLink and route there.
+- **Single entry point:** `MolliePay.create_payment_link(amount:, description:, ...)` as a class method only. No Billable method. If a Billable wants a link, they pass `customer: mollie_customer`.
+- **SDK note:** `Mollie::PaymentLink` has a custom `resource_name` returning `"payment-links"` (hyphenated). Be aware of this when constructing API calls.
+
+**Schema:**
+```ruby
+create_table :mollie_pay_payment_links do |t|
+  t.string :mollie_id, null: false, index: { unique: true }
+  t.references :customer, foreign_key: { to_table: :mollie_pay_customers }
+  t.integer :amount, null: false
+  t.string :currency, null: false, default: "EUR"
+  t.string :description
+  t.string :status, null: false, default: "active"
+  t.string :payment_link_url
+  t.datetime :paid_at
+  t.datetime :expires_at
+  t.timestamps
+end
+
+# Add link back from payments to payment links (for customer-linked payment link payments)
+add_reference :mollie_pay_payments, :payment_link,
+  foreign_key: { to_table: :mollie_pay_payment_links }
+```
+
+**Webhook handling for anonymous payment link payments:**
+
+In `ProcessWebhookJob#sync_payment`, after fetching the Mollie payment:
+1. If `mp.customer_id` is present → existing `Payment.record_from_mollie` flow (unchanged)
+2. If `mp.customer_id` is nil → check if payment has `_links.paymentLink`. If so, find the local `PaymentLink` and fire `ActiveSupport::Notifications.instrument("mollie_pay.payment_link_paid", payment_link: link, mollie_payment: mp)`
+3. If no customer AND no payment link → log and discard (unknown origin)
+
+**Files:**
+- `db/migrate/XXXXXX_create_mollie_pay_payment_links.rb`
+- `db/migrate/XXXXXX_add_payment_link_id_to_mollie_pay_payments.rb`
+- `app/models/mollie_pay/payment_link.rb`
+- `app/models/mollie_pay/payment.rb` (add optional `belongs_to :payment_link`)
+- `app/jobs/mollie_pay/process_webhook_job.rb` (add anonymous payment path)
+- `lib/mollie_pay.rb` (class-level `create_payment_link`)
+- `test/models/mollie_pay/payment_link_test.rb`
+- `test/jobs/mollie_pay/process_webhook_job_test.rb`
+- `lib/mollie_pay/test_fixtures/payment_link.json`
+
+**Acceptance Criteria:**
+- [ ] PaymentLink model with CRUD operations
+- [ ] `customer_id` on payments stays NOT NULL
+- [ ] `MolliePay.create_payment_link(amount:, description:, customer: nil)` class method
+- [ ] Customer-linked payment links: resulting payments flow through normal `record_from_mollie`
+- [ ] Anonymous payment links: handled via separate code path in `ProcessWebhookJob`
+- [ ] `ActiveSupport::Notifications` fires for anonymous payment link payments
+- [ ] Payment gains optional `belongs_to :payment_link` association
+- [ ] Tests for both customer-linked and anonymous payment link flows
+
+---
+
+## Phase 4: Settlement Notifications
+
+**Why fourth:** Settlements are important for financial reconciliation. Mollie sends `stl_` webhooks. This is lightweight — no AR model, just webhook routing and notification.
+
+### 4.1 Settlement Webhook Handling (No AR Model)
+
+**Architecture decision (revised from review):** Settlements are account-level, not customer-level. They do not fit the Billable pattern. A full AR model adds migration, model file, tests, and a table for data the host app can fetch from Mollie directly. Instead: handle `stl_` webhooks with `ActiveSupport::Notifications` only.
+
+**Solution:**
+- `stl_` prefix in `ProcessWebhookJob` fetches `Mollie::Settlement.get(mollie_id)` and fires `ActiveSupport::Notifications.instrument("mollie_pay.settlement_received", settlement: mollie_settlement)`
+- The host app subscribes in an initializer to react
+- The `previous_status` guard pattern is applied: store the last-seen settlement status in `Rails.cache` keyed by `mollie_id` to avoid duplicate notifications on webhook replays
+
+**Research Insights:**
+- **Single notification mechanism.** The original plan had both `ActiveSupport::Notifications` AND a configurable `on_settlement` callback. DHH reviewer and simplicity reviewer both said: pick one. AS::Notifications is the Rails-standard answer.
+- **Idempotency for callbacks:** Document that `mollie_pay.settlement_received` subscribers must be idempotent. Settlement webhooks can replay. Include settlement status in the notification payload so consumers can check `settlement.status == "paidout"` before acting.
+- **Settlement amounts can be negative** (Mollie deducts fees). Document this for consumers.
+
+**Files:**
+- `app/jobs/mollie_pay/process_webhook_job.rb` (add `stl_` routing)
+- `test/jobs/mollie_pay/process_webhook_job_test.rb`
+
+**Acceptance Criteria:**
+- [ ] `stl_` webhooks fetch settlement from Mollie API
+- [ ] `ActiveSupport::Notifications` fires `mollie_pay.settlement_received`
+- [ ] Notification includes full Mollie settlement object
+- [ ] No AR model, no migration
+- [ ] Documentation for host app subscription pattern
+- [ ] Tests with WebMock stubs
+
+---
+
+## System-Wide Impact
+
+### Interaction Graph
+
+- `POST /mollie_pay/webhooks` → `WebhooksController#create` → `ProcessWebhookJob` → routes by prefix → `Model.record_from_mollie` → `notify_billable` → `owner.on_mollie_*`
+- New: `tr_` with changed `amount_charged_back` → enqueues `SyncChargebacksJob` → fetches chargebacks → `on_mollie_chargeback_received`
+- New: `tr_` with no `customer_id` → checks for PaymentLink → `ActiveSupport::Notifications`
+- New: `stl_` → fetches settlement → `ActiveSupport::Notifications`
+
+### Error Propagation
+
+- All new Mollie API calls wrapped in existing `mollie-api-ruby` error handling
+- New error classes: `CaptureNotAllowed`, `PaymentNotCancelable`
+- All inherit from `MolliePay::Error`
+- `ProcessWebhookJob` uses branch-specific `RecordNotFound` handling (not blanket `discard_on`)
+- `SyncChargebacksJob` has its own retry logic (5 attempts, polynomial backoff)
+
+### State Lifecycle Risks
+
+- **Chargeback detection** enqueues a separate job, isolating failure from payment state updates
+- **Payment link webhook** has a separate code path for anonymous payments — does not touch `record_from_mollie`
+- **`customer_id` stays NOT NULL** — no migration risk on existing constraint
+
+### API Surface
+
+| Billable Method | Phase |
+|---|---|
+| `mollie_capture(payment, amount:)` | 2 |
+| `mollie_update_payment(payment, ...)` | 2 |
+| `mollie_cancel_payment(payment)` | 2 |
+
+| MolliePay Class Method | Phase |
+|---|---|
+| `MolliePay.create_payment_link(...)` | 3 |
+
+| New Hook | Phase |
+|---|---|
+| `on_mollie_payment_authorized` | 1 |
+| `on_mollie_chargeback_received(chargeback)` | 2 |
+
+| ActiveSupport::Notifications Event | Phase |
+|---|---|
+| `mollie_pay.payment_link_paid` | 3 |
+| `mollie_pay.settlement_received` | 4 |
+
+---
+
+## ERD (New Models)
+
+```mermaid
+erDiagram
+    Customer ||--o{ Payment : "has many"
+    Customer ||--o{ Subscription : "has many"
+    Customer ||--o{ Mandate : "has many"
+    Customer ||--o{ PaymentLink : "has many (optional)"
+    Payment ||--o{ Refund : "has many"
+    Payment ||--o{ Chargeback : "has many"
+    PaymentLink ||--o{ Payment : "has many"
+```
+
+---
+
+## Migration Summary
+
+| Phase | Migration | Risk |
+|---|---|---|
+| 1 | `add_authorized_at_to_mollie_pay_payments` | Low — new nullable column |
+| 1 | `add_amount_tracking_to_mollie_pay_payments` | Low — new columns with defaults |
+| 2 | `create_mollie_pay_chargebacks` | Low — new table |
+| 3 | `create_mollie_pay_payment_links` | Low — new table |
+| 3 | `add_payment_link_id_to_mollie_pay_payments` | Low — new nullable FK |
+
+---
+
+## New Hooks & Notifications Summary
+
+| Hook/Event | Phase | Trigger | Mechanism |
+|---|---|---|---|
+| `on_mollie_payment_authorized` | 1 | Payment enters authorized state | Billable hook |
+| `on_mollie_chargeback_received(chargeback)` | 2 | Chargeback detected on payment | Billable hook |
+| `mollie_pay.payment_link_paid` | 3 | Anonymous payment link paid | AS::Notifications |
+| `mollie_pay.settlement_received` | 4 | Settlement webhook received | AS::Notifications |
+
+---
+
+## What Is NOT in This Plan
+
+The following Mollie API resources are intentionally excluded. Host apps should use `mollie-api-ruby` directly for these:
+
+| Resource | Why Excluded |
+|---|---|
+| **Orders API** | E-commerce domain, not SaaS billing. Different lifecycle (lines, shipments, fulfillment). |
+| **Payment Methods** | Read-only listing. Use `Mollie::Method.all` / `Mollie::Method.all_available` directly. |
+| **Balances** | Account-level read-only. Use `Mollie::Balance.all` directly. |
+| **Invoices** | Mollie billing invoices. Use `Mollie::Invoice.all` directly. |
+| **Profiles** | Account management. Use `Mollie::Profile.all` directly. |
+| **Organizations** | Account info. Use `Mollie::Organization.get` directly. |
+| **Terminals** | POS devices. Use `Mollie::Terminal.all` directly. |
+| **Apple Pay Sessions** | Stateless validation. Use `Mollie::Client` to POST to wallets endpoint directly. |
+| **Mollie Connect** | Requires per-request token passing through all models. Separate plan. Note: `Mollie::Client.with_api_key` block already supports this — less invasive than originally assumed. |
+
+---
+
+## Test Strategy
+
+### AR Fixtures (test/fixtures/mollie_pay/)
+
+- `chargebacks.yml` — references `acme_first` payment fixture
+- `payment_links.yml` — one with customer, one without
+
+### Mollie API Response Stubs (lib/mollie_pay/test_fixtures/)
+
+- `chargeback.json` — single chargeback response
+- `payment_link.json` — payment link response
+
+### Test Helpers
+
+- Add `stub_mollie_chargeback_list` and `webmock_mollie_chargeback_list` to `MolliePay::TestHelper`
+- Add `stub_mollie_capture_create` and `webmock_mollie_capture_create`
+- Add `stub_mollie_payment_link_create` and `webmock_mollie_payment_link_create`
+- For SyncChargebacksJob, stub `Mollie::Payment::Chargeback.all` to return an array of OpenStruct objects
+
+---
+
+## SDK Reference (mollie-api-ruby v4.19.0)
+
+Key SDK classes used by this plan:
+
+| SDK Class | MolliePay Usage |
+|---|---|
+| `Mollie::Payment::Chargeback` | `SyncChargebacksJob` fetches via `.all(payment_id:)` |
+| `Mollie::Payment::Capture` | `mollie_capture` creates via `.create(payment_id:, amount:)` (inherited from Base) |
+| `Mollie::PaymentLink` | `MolliePay.create_payment_link` creates via `.create(...)` |
+| `Mollie::Settlement` | Settlement webhook handler fetches via `.get(id)` |
+
+**SDK gotchas:**
+- `Mollie::PaymentLink` has custom `resource_name` returning `"payment-links"` (hyphenated)
+- `Util.camelize_keys` only recurses for whitelisted keys (`:lines`, `:billing_address`, etc.)
+- Per-request API keys: pass `api_key:` in any request, or use `Mollie::Client.with_api_key` block
+
+---
+
+## Sources
+
+### Mollie API Reference
+- Full API overview: https://docs.mollie.com/reference/overview
+- Payments API: https://docs.mollie.com/reference/create-payment
+- Captures API: https://docs.mollie.com/reference/create-capture
+- Payment Links API: https://docs.mollie.com/reference/create-payment-link
+- Settlements API: https://docs.mollie.com/reference/get-settlement
+- Chargebacks API: https://docs.mollie.com/reference/get-chargeback
+
+### Internal References
+- Architecture: `AGENTS.md`
+- Current models: `app/models/mollie_pay/`
+- Webhook flow: `app/jobs/mollie_pay/process_webhook_job.rb`
+- Billable concern: `app/models/mollie_pay/billable.rb`
+- Configuration: `lib/mollie_pay/configuration.rb`
+
+### External Research
+- Pay gem chargeback handling: https://github.com/pay-rails/pay
+- Stripe dispute patterns: https://docs.stripe.com/disputes/how-disputes-work
+- Webhook idempotency: https://hookdeck.com/webhooks/guides/implement-webhook-idempotency
+- mollie-api-ruby SDK source: https://github.com/mollie/mollie-api-ruby

--- a/test/controllers/mollie_pay/webhooks_controller_test.rb
+++ b/test/controllers/mollie_pay/webhooks_controller_test.rb
@@ -26,6 +26,14 @@ module MolliePay
       assert_response :ok
     end
 
+    test "accepts settlement webhook" do
+      assert_enqueued_with(job: MolliePay::ProcessWebhookJob, args: [ "stl_abc123" ]) do
+        post mollie_pay.webhooks_url, params: { id: "stl_abc123" }
+      end
+
+      assert_response :ok
+    end
+
     test "returns 422 without id param" do
       assert_no_enqueued_jobs only: MolliePay::ProcessWebhookJob do
         post mollie_pay.webhooks_url, params: {}
@@ -37,6 +45,23 @@ module MolliePay
     test "returns 422 with invalid mollie_id format" do
       assert_no_enqueued_jobs only: MolliePay::ProcessWebhookJob do
         post mollie_pay.webhooks_url, params: { id: "invalid_format" }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
+    test "returns 422 for unknown prefix" do
+      assert_no_enqueued_jobs only: MolliePay::ProcessWebhookJob do
+        post mollie_pay.webhooks_url, params: { id: "zz_unknown" }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
+    test "returns 422 for excessively long mollie_id" do
+      long_id = "tr_#{"a" * 65}"
+      assert_no_enqueued_jobs only: MolliePay::ProcessWebhookJob do
+        post mollie_pay.webhooks_url, params: { id: long_id }
       end
 
       assert_response :unprocessable_entity

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -36,6 +36,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_120000) do
 
   create_table "mollie_pay_payments", force: :cascade do |t|
     t.integer "amount", null: false
+    t.integer "amount_captured", default: 0
+    t.integer "amount_charged_back", default: 0
+    t.integer "amount_refunded", default: 0
+    t.integer "amount_remaining"
+    t.datetime "authorized_at"
     t.datetime "canceled_at"
     t.string "checkout_url"
     t.datetime "created_at", null: false

--- a/test/jobs/mollie_pay/process_webhook_job_test.rb
+++ b/test/jobs/mollie_pay/process_webhook_job_test.rb
@@ -43,6 +43,33 @@ module MolliePay
       assert_equal "refunded", refund.reload.status
     end
 
+    test "processes settlement webhook via ActiveSupport::Notifications" do
+      settlement = OpenStruct.new(
+        id: "stl_test123", status: "paidout",
+        amount: OpenStruct.new(value: "100.00", currency: "EUR")
+      )
+
+      received = nil
+      ActiveSupport::Notifications.subscribe("mollie_pay.settlement_received") do |*, payload|
+        received = payload[:settlement]
+      end
+
+      Mollie::Settlement.stub(:get, settlement) do
+        ProcessWebhookJob.perform_now("stl_test123")
+      end
+
+      assert_equal "stl_test123", received.id
+      assert_equal "paidout", received.status
+    ensure
+      ActiveSupport::Notifications.unsubscribe("mollie_pay.settlement_received")
+    end
+
+    test "logs unknown webhook prefix" do
+      assert_nothing_raised do
+        ProcessWebhookJob.perform_now("ord_unknown123")
+      end
+    end
+
     test "retries on failure" do
       Mollie::Payment.stub(:get, ->(_) { raise StandardError, "Mollie down" }) do
         assert_enqueued_with(job: ProcessWebhookJob) do

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -522,6 +522,7 @@ module MolliePay
         @org.on_mollie_payment_paid(payment)
         @org.on_mollie_payment_failed(payment)
         @org.on_mollie_payment_canceled(payment)
+        @org.on_mollie_payment_authorized(payment)
         @org.on_mollie_payment_expired(payment)
         @org.on_mollie_first_payment_paid(payment)
         @org.on_mollie_subscription_charged(payment)
@@ -530,6 +531,24 @@ module MolliePay
         @org.on_mollie_subscription_completed(subscription)
         @org.on_mollie_mandate_created(mandate)
         @org.on_mollie_refund_processed(refund)
+      end
+    end
+
+    test "mollie_refund raises error for payment not belonging to this customer" do
+      other_org = Organization.create!(name: "Other Org", email: "other@org.nl")
+      other_customer = MolliePay::Customer.create!(mollie_id: "cst_other", owner: other_org)
+      other_payment = MolliePay::Payment.create!(
+        customer: other_customer,
+        mollie_id: "tr_other",
+        status: "paid",
+        amount: 5000,
+        currency: "EUR",
+        sequence_type: "oneoff",
+        paid_at: Time.current
+      )
+
+      assert_raises(MolliePay::Error) do
+        @org.mollie_refund(other_payment)
       end
     end
   end

--- a/test/models/mollie_pay/payment_test.rb
+++ b/test/models/mollie_pay/payment_test.rb
@@ -120,6 +120,71 @@ module MolliePay
       assert_nil payment.subscription
     end
 
+    test "record_from_mollie sets authorized_at on first authorized observation" do
+      customer = mollie_pay_customers(:acme)
+
+      mollie_payment = stub_mollie_payment(
+        id:            "tr_auth1",
+        status:        "authorized",
+        customer_id:   customer.mollie_id,
+        sequence_type: "oneoff",
+        amount_value:  "50.00",
+        amount_currency: "EUR"
+      )
+
+      payment = Payment.record_from_mollie(mollie_payment)
+      assert_not_nil payment.authorized_at
+
+      original_authorized_at = payment.authorized_at
+      Payment.record_from_mollie(mollie_payment)
+      assert_equal original_authorized_at, payment.reload.authorized_at
+    end
+
+    test "record_from_mollie populates amount tracking columns" do
+      customer = mollie_pay_customers(:acme)
+
+      mollie_payment = stub_mollie_payment(
+        id:              "tr_tracked",
+        status:          "paid",
+        customer_id:     customer.mollie_id,
+        sequence_type:   "oneoff",
+        amount_value:    "100.00",
+        amount_currency: "EUR",
+        amount_refunded: OpenStruct.new(value: "10.00", currency: "EUR"),
+        amount_remaining: OpenStruct.new(value: "90.00", currency: "EUR"),
+        amount_captured: OpenStruct.new(value: "100.00", currency: "EUR"),
+        amount_charged_back: OpenStruct.new(value: "5.00", currency: "EUR")
+      )
+
+      payment = Payment.record_from_mollie(mollie_payment)
+
+      assert_equal 1000, payment.amount_refunded
+      assert_equal 9000, payment.amount_remaining
+      assert_equal 10000, payment.amount_captured
+      assert_equal 500, payment.amount_charged_back
+    end
+
+    test "record_from_mollie preserves amount tracking when Mollie omits fields" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_payments(:acme_oneoff)
+
+      mollie_payment = stub_mollie_payment(
+        id:              existing.mollie_id,
+        status:          "paid",
+        customer_id:     customer.mollie_id,
+        sequence_type:   "oneoff",
+        amount_value:    "75.00",
+        amount_currency: "EUR"
+      )
+
+      Payment.record_from_mollie(mollie_payment)
+
+      assert_equal 0, existing.reload.amount_refunded
+      assert_nil existing.amount_remaining
+      assert_equal 0, existing.amount_captured
+      assert_equal 0, existing.amount_charged_back
+    end
+
     test "record_from_mollie skips notify_billable when status unchanged" do
       existing = mollie_pay_payments(:acme_first)
       assert_equal "paid", existing.status
@@ -142,16 +207,22 @@ module MolliePay
 
     private
 
-    def stub_mollie_payment(id:, status:, customer_id:, sequence_type:, amount_value:, amount_currency:, subscription_id: nil)
+    def stub_mollie_payment(id:, status:, customer_id:, sequence_type:, amount_value:, amount_currency:,
+                            subscription_id: nil, amount_refunded: nil, amount_remaining: nil,
+                            amount_captured: nil, amount_charged_back: nil)
       amount = OpenStruct.new(value: amount_value, currency: amount_currency)
       OpenStruct.new(
-        id:              id,
-        status:          status,
-        customer_id:     customer_id,
-        sequence_type:   sequence_type,
-        amount:          amount,
-        mandate_id:      nil,
-        subscription_id: subscription_id
+        id:                  id,
+        status:              status,
+        customer_id:         customer_id,
+        sequence_type:       sequence_type,
+        amount:              amount,
+        mandate_id:          nil,
+        subscription_id:     subscription_id,
+        amount_refunded:     amount_refunded,
+        amount_remaining:    amount_remaining,
+        amount_captured:     amount_captured,
+        amount_charged_back: amount_charged_back
       )
     end
   end


### PR DESCRIPTION
## Summary

Phase 1 of the [full Mollie API support plan](https://github.com/peterberkenbosch/mollie_pay/issues/56). Extends webhook infrastructure, adds payment authorized state, amount tracking, and ownership verification — the foundation that unblocks Phases 2-4.

- **Webhook regex**: extensible allowlist `(tr|sub|re|stl)_` with 64-char length cap (prevents queue abuse)
- **Branch-specific RecordNotFound**: removed blanket `discard_on`, subscription/refund handle it locally with logging. Prevents silent data loss for future payment link payments.
- **Settlement webhooks**: `stl_` prefix routes to `Mollie::Settlement.get` → `ActiveSupport::Notifications.instrument("mollie_pay.settlement_received")`
- **Unknown prefixes**: logged via `Rails.logger.warn` instead of silently dropped
- **`authorized_at`**: new column + `on_mollie_payment_authorized` hook (enables Klarna/BNPL capture flows)
- **Amount tracking**: `amount_refunded`, `amount_remaining`, `amount_captured`, `amount_charged_back` (integer cents, populated from Mollie payment object)
- **Ownership verification**: `verify_payment_ownership!` on `mollie_refund` prevents cross-customer refund attacks

## Test plan

- [x] 129 tests pass, 264 assertions, 0 failures
- [x] Rubocop clean (74 files, 0 offenses)
- [x] New tests: settlement AS::Notifications, unknown prefix logging, authorized_at idempotency, amount tracking population/preservation, ownership verification cross-customer, length cap rejection
- [x] All existing tests pass unchanged

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a library gem, not a deployed service. Changes are validated via the test suite. Host apps will pick up changes on next gem update.

## Closes

- Closes #44 (webhook routing)
- Closes #45 (authorized state)
- Closes #46 (amount tracking)
- Related: #56 (tracking umbrella)