### PR TITLE
feat(chargebacks): Add Chargeback model with detection via payment webhook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ app/
     billable.rb                 # concern included by host app model
     customer.rb
     mandate.rb
+    chargeback.rb
     payment.rb
     refund.rb
     subscription.rb
@@ -197,6 +198,8 @@ Event hooks (override in host model, all no-ops by default):
 - `on_mollie_subscription_completed`
 - `on_mollie_mandate_created`
 - `on_mollie_refund_processed`
+- `on_mollie_chargeback_received`
+- `on_mollie_chargeback_reversed`
 
 ---
 

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -131,6 +131,8 @@ module MolliePay
     def on_mollie_subscription_completed(subscription); end
     def on_mollie_mandate_created(mandate)          ; end
     def on_mollie_refund_processed(refund)          ; end
+    def on_mollie_chargeback_received(chargeback)  ; end
+    def on_mollie_chargeback_reversed(chargeback)  ; end
 
     private
 

--- a/app/models/mollie_pay/chargeback.rb
+++ b/app/models/mollie_pay/chargeback.rb
@@ -62,18 +62,19 @@ module MolliePay
 
     private
 
-      # The Mollie API returns reason and reasonCode on chargebacks, but the
-      # mollie-api-ruby SDK does not expose them via attr_accessor. Access
+      # The Mollie API returns reason as an object: {"code": "AM04", "description": "Insufficient funds"}
+      # The mollie-api-ruby SDK does not expose this via attr_accessor. Access
       # via the raw attributes hash instead.
       def self.extract_reason(mollie_chargeback)
-        attrs = mollie_chargeback.try(:attributes) || {}
-        reason      = attrs["reason"]
-        reason_code = attrs["reasonCode"] || attrs["reason_code"]
+        reason = (mollie_chargeback.try(:attributes) || {})["reason"]
+        return nil if reason.nil?
 
-        if reason && reason_code
-          "#{reason} (#{reason_code})"
+        if reason.is_a?(Hash)
+          description = reason["description"]
+          code        = reason["code"]
+          code ? "#{description} (#{code})" : description
         else
-          reason || reason_code
+          reason.to_s
         end
       end
   end

--- a/app/models/mollie_pay/chargeback.rb
+++ b/app/models/mollie_pay/chargeback.rb
@@ -1,0 +1,63 @@
+module MolliePay
+  class Chargeback < ApplicationRecord
+    belongs_to :payment
+
+    validates :mollie_id, presence: true, uniqueness: true
+    validates :amount,    presence: true, numericality: { greater_than: 0 }
+    validates :currency,  presence: true
+
+    def self.sync_for_payment(payment)
+      mollie_chargebacks = payment.mollie_record.chargebacks
+      return if mollie_chargebacks.blank?
+
+      billable = payment.customer.owner
+      events = []
+
+      mollie_chargebacks.each do |mc|
+        chargeback = find_or_initialize_by(mollie_id: mc.id)
+        was_new = chargeback.new_record?
+        was_reversed = chargeback.reversed_at
+
+        chargeback.update!(
+          payment:           payment,
+          amount:            mollie_value_to_cents(mc.amount),
+          currency:          mc.amount.currency,
+          reason:            mc.reason&.to_s,
+          created_at_mollie: mc.created_at,
+          reversed_at:       mc.reversed_at
+        )
+
+        if was_new
+          events << [ :received, chargeback ]
+        elsif chargeback.reversed_at.present? && was_reversed.nil?
+          events << [ :reversed, chargeback ]
+        end
+      rescue ActiveRecord::RecordNotUnique
+        find_by!(mollie_id: mc.id)
+      end
+
+      events.each do |type, chargeback|
+        case type
+        when :received then billable.on_mollie_chargeback_received(chargeback)
+        when :reversed then billable.on_mollie_chargeback_reversed(chargeback)
+        end
+      end
+    end
+
+    def reversed?
+      reversed_at.present?
+    end
+
+    def mollie_record
+      Mollie::Payment::Chargeback.get(mollie_id, payment_id: payment.mollie_id)
+    end
+
+    def amount_decimal
+      amount / 100.0
+    end
+
+    def mollie_amount
+      { currency: currency, value: format("%.2f", amount_decimal) }
+    end
+  end
+end

--- a/app/models/mollie_pay/chargeback.rb
+++ b/app/models/mollie_pay/chargeback.rb
@@ -22,6 +22,7 @@ module MolliePay
           payment:           payment,
           amount:            mollie_value_to_cents(mc.amount),
           currency:          mc.amount.currency,
+          reason:            extract_reason(mc),
           created_at_mollie: mc.created_at,
           reversed_at:       mc.reversed_at
         )
@@ -58,5 +59,22 @@ module MolliePay
     def mollie_amount
       { currency: currency, value: format("%.2f", amount_decimal) }
     end
+
+    private
+
+      # The Mollie API returns reason and reasonCode on chargebacks, but the
+      # mollie-api-ruby SDK does not expose them via attr_accessor. Access
+      # via the raw attributes hash instead.
+      def self.extract_reason(mollie_chargeback)
+        attrs = mollie_chargeback.try(:attributes) || {}
+        reason      = attrs["reason"]
+        reason_code = attrs["reasonCode"] || attrs["reason_code"]
+
+        if reason && reason_code
+          "#{reason} (#{reason_code})"
+        else
+          reason || reason_code
+        end
+      end
   end
 end

--- a/app/models/mollie_pay/chargeback.rb
+++ b/app/models/mollie_pay/chargeback.rb
@@ -22,7 +22,6 @@ module MolliePay
           payment:           payment,
           amount:            mollie_value_to_cents(mc.amount),
           currency:          mc.amount.currency,
-          reason:            mc.reason&.to_s,
           created_at_mollie: mc.created_at,
           reversed_at:       mc.reversed_at
         )

--- a/app/models/mollie_pay/payment.rb
+++ b/app/models/mollie_pay/payment.rb
@@ -5,7 +5,8 @@ module MolliePay
 
     belongs_to :customer
     belongs_to :subscription, optional: true
-    has_many   :refunds, dependent: :destroy
+    has_many   :refunds,      dependent: :destroy
+    has_many   :chargebacks,  dependent: :destroy
 
     # amount_remaining uses nil-semantics: nil = "never fetched from Mollie",
     # 0 = "fully captured/refunded". Only populated when Mollie includes the field.
@@ -27,6 +28,7 @@ module MolliePay
 
       payment = find_or_initialize_by(mollie_id: mp.id)
       previous_status = payment.status
+      previous_amount_charged_back = payment.amount_charged_back
 
       # Link recurring payments to their subscription
       if mp.subscription_id.present? && payment.subscription_id.nil?
@@ -52,6 +54,7 @@ module MolliePay
       )
 
       payment.notify_billable(mp) if payment.status != previous_status
+      Chargeback.sync_for_payment(payment) if payment.amount_charged_back != previous_amount_charged_back
       payment
     rescue ActiveRecord::RecordNotUnique
       find_by!(mollie_id: mp.id)

--- a/db/migrate/20260321000001_create_mollie_pay_chargebacks.rb
+++ b/db/migrate/20260321000001_create_mollie_pay_chargebacks.rb
@@ -1,0 +1,15 @@
+class CreateMolliePayChargebacks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mollie_pay_chargebacks do |t|
+      t.references :payment, null: false,
+        foreign_key: { to_table: :mollie_pay_payments }
+      t.string   :mollie_id, null: false, index: { unique: true }
+      t.integer  :amount,    null: false
+      t.string   :currency,  null: false, default: "EUR"
+      t.string   :reason
+      t.datetime :created_at_mollie
+      t.datetime :reversed_at
+      t.timestamps
+    end
+  end
+end

--- a/docs/plans/2026-03-21-001-feat-chargeback-model-webhook-detection-plan.md
+++ b/docs/plans/2026-03-21-001-feat-chargeback-model-webhook-detection-plan.md
@@ -1,0 +1,225 @@
+---
+title: "feat: Add Chargeback model with detection via payment webhook"
+type: feat
+status: completed
+date: 2026-03-21
+github_issue: 47
+---
+
+# feat: Add Chargeback model with detection via payment webhook
+
+## Overview
+
+Chargebacks are invisible in the current architecture. Mollie does NOT send separate chargeback webhooks — chargebacks arrive embedded in the payment object via `tr_` webhooks. The payment status stays "paid", only `amountChargedBack` changes. The current `previous_status` guard will never detect them.
+
+This is a **critical business event** — chargebacks require immediate action (disable access, flag account, notify finance).
+
+## Problem Statement
+
+When a card issuer initiates a chargeback against a Mollie payment, Mollie updates the payment object's `amountChargedBack` field and fires the payment's webhook (`tr_` prefix). The current `Payment.record_from_mollie` syncs `amount_charged_back` to the local column but never inspects it for changes. There is no Chargeback model, no detection logic, and no hook to notify the host application.
+
+## Proposed Solution
+
+1. New `MolliePay::Chargeback` model with `record_from_mollie`
+2. Detect chargebacks in `Payment.record_from_mollie` by comparing `amount_charged_back` before and after the update
+3. When `amount_charged_back` **changes** (increase = new chargeback, decrease = reversal), delegate to `Chargeback.sync_for_payment(payment)` which fetches all chargebacks from Mollie API and upserts
+4. Fire `on_mollie_chargeback_received(chargeback)` for each **new** chargeback
+5. Fire `on_mollie_chargeback_reversed(chargeback)` when `reversed_at` changes from nil to a value
+
+## Technical Approach
+
+### Detection Mechanism
+
+The key insight: chargeback detection cannot use the `previous_status` pattern because payment status doesn't change. Instead, compare `amount_charged_back` values.
+
+In `Payment.record_from_mollie`:
+```ruby
+previous_amount_charged_back = payment.amount_charged_back
+payment.update!(...)
+if payment.amount_charged_back != previous_amount_charged_back
+  Chargeback.sync_for_payment(payment)
+end
+```
+
+### Chargeback Sync Strategy
+
+`Chargeback.sync_for_payment(payment)` fetches **all** chargebacks for the payment from Mollie API, then upserts each one. This handles:
+- First chargeback: creates new record, fires hook
+- Additional chargebacks: existing ones are no-ops (already persisted), new ones created
+- Reversals: existing records updated with `reversed_at`, fires reversal hook
+- Idempotent replays: `find_or_initialize_by(mollie_id:)` ensures no duplicates
+
+### Mollie API Call
+
+```ruby
+# mollie-api-ruby provides:
+payment.mollie_record.chargebacks  # returns collection of chargeback objects
+# Each chargeback has: id, amount, createdAt, reversedAt, reason, paymentId
+```
+
+### Hook Firing Logic
+
+Since chargebacks have no status field, hook idempotency uses different signals:
+- **New chargeback:** `new_record?` is true before save → fire `on_mollie_chargeback_received`
+- **Reversed chargeback:** `reversed_at` changed from nil to a value → fire `on_mollie_chargeback_reversed`
+- **Already processed:** record exists, no meaningful changes → no hook fires
+
+## Schema
+
+```ruby
+create_table :mollie_pay_chargebacks do |t|
+  t.references :payment, null: false,
+    foreign_key: { to_table: :mollie_pay_payments }
+  t.string :mollie_id, null: false, index: { unique: true }
+  t.integer :amount, null: false
+  t.string :currency, null: false, default: "EUR"
+  t.string :reason
+  t.datetime :created_at_mollie
+  t.datetime :reversed_at
+  t.timestamps
+end
+```
+
+### ERD
+
+```mermaid
+erDiagram
+    Customer ||--o{ Payment : "has_many"
+    Payment ||--o{ Refund : "has_many"
+    Payment ||--o{ Chargeback : "has_many"
+
+    Chargeback {
+        integer id PK
+        integer payment_id FK
+        string mollie_id UK
+        integer amount
+        string currency
+        string reason
+        datetime created_at_mollie
+        datetime reversed_at
+        datetime created_at
+        datetime updated_at
+    }
+```
+
+## Implementation Phases
+
+### Phase 1: Migration & Model
+
+**Files to create:**
+- `db/migrate/TIMESTAMP_create_mollie_pay_chargebacks.rb`
+- `app/models/mollie_pay/chargeback.rb`
+
+**Files to modify:**
+- `app/models/mollie_pay/payment.rb` — add `has_many :chargebacks, dependent: :destroy`
+
+The Chargeback model follows the Refund pattern (`app/models/mollie_pay/refund.rb`):
+- `belongs_to :payment`
+- `mollie_value_to_cents` for amount conversion
+- `sync_for_payment(payment)` class method (fetches from Mollie API, upserts, fires hooks)
+- No status column, no status constants (chargebacks don't have status transitions)
+- Convenience predicates: `reversed?`
+
+### Phase 2: Detection in Payment
+
+**Files to modify:**
+- `app/models/mollie_pay/payment.rb` — add chargeback detection in `record_from_mollie`
+
+After `payment.update!(...)`, compare `amount_charged_back`:
+```ruby
+previous_amount_charged_back = payment.amount_charged_back
+payment.update!(...)
+
+# Existing status-change hook
+payment.notify_billable if payment.status != previous_status
+
+# New chargeback detection (orthogonal to status changes)
+if payment.amount_charged_back != previous_amount_charged_back
+  Chargeback.sync_for_payment(payment)
+end
+```
+
+### Phase 3: Billable Hooks
+
+**Files to modify:**
+- `app/models/mollie_pay/billable.rb` — add no-op hook methods
+
+```ruby
+def on_mollie_chargeback_received(chargeback) ; end
+def on_mollie_chargeback_reversed(chargeback) ; end
+```
+
+### Phase 4: Tests & Fixtures
+
+**Files to create:**
+- `test/fixtures/mollie_pay/chargebacks.yml`
+- `test/models/mollie_pay/chargeback_test.rb`
+- `lib/mollie_pay/test_fixtures/chargeback.json` (if needed for WebMock stubs)
+
+**Files to modify:**
+- `test/fixtures/mollie_pay/payments.yml` — add payment with `amount_charged_back: 500`
+- `lib/mollie_pay/test_helper.rb` — add chargeback test stubs
+- `test/models/mollie_pay/payment_test.rb` — test chargeback detection logic
+- `test/jobs/mollie_pay/process_webhook_job_test.rb` — test chargeback detection via payment webhook
+
+**Test scenarios:**
+1. `sync_for_payment` creates new chargeback from Mollie data
+2. `sync_for_payment` is idempotent — same chargeback not duplicated
+3. `sync_for_payment` fires `on_mollie_chargeback_received` for new chargebacks only
+4. `sync_for_payment` detects reversal and fires `on_mollie_chargeback_reversed`
+5. `Payment.record_from_mollie` triggers sync when `amount_charged_back` changes
+6. `Payment.record_from_mollie` does NOT trigger sync when `amount_charged_back` unchanged
+7. Concurrent INSERT race handled by `RecordNotUnique` rescue
+8. `reversed?` predicate returns correct values
+
+### Phase 5: Documentation
+
+**Files to modify:**
+- `AGENTS.md` — add `chargeback.rb` to architecture diagram, add hooks to Billable section
+
+## System-Wide Impact
+
+- **Interaction graph:** `tr_` webhook → `ProcessWebhookJob` → `Payment.record_from_mollie` → `Chargeback.sync_for_payment` → `on_mollie_chargeback_received` on Billable owner. Two levels deep from existing webhook flow.
+- **Error propagation:** If `Chargeback.sync_for_payment` raises (e.g., Mollie API error), it propagates up through `Payment.record_from_mollie` → `ProcessWebhookJob`, which has polynomial backoff (5 attempts). This is correct — the entire payment webhook should retry.
+- **State lifecycle risks:** If the payment updates successfully but chargeback sync fails, the payment's `amount_charged_back` will be correct but no Chargeback record exists. On retry, the `amount_charged_back` comparison will be `N != N` (no change detected, since it was already persisted). **Mitigation:** Compare against the value *before* the `update!` call, captured in a local variable. On retry, the Mollie API will return the same payment data, the payment update will be a no-op, and the comparison will correctly detect no change. However, this means the chargeback fetch never retries. **Solution:** Always fetch chargebacks when `amount_charged_back > 0` and local chargeback count doesn't match expected count, OR capture `previous_amount_charged_back` before `update!` so the comparison works even on first run after the payment was already updated.
+- **API surface parity:** No other interface exposes chargeback functionality. This is the only entry point.
+
+## Design Decisions
+
+1. **No `chb_` webhook routing** — Mollie sends chargebacks via `tr_` payment webhooks. No changes to `WebhooksController` or `ProcessWebhookJob` routing.
+2. **No `mollie_chargebacks` through association on Billable** — Rails doesn't natively support nested through (Customer → Payment → Chargeback). Host apps can use `organization.mollie_payments.joins(:chargebacks)`.
+3. **No status column** — Chargebacks don't have Mollie status transitions. `reversed_at` serves as implicit status indicator.
+4. **`reason` as single string** — Store the human-readable description. Structured reason codes can be fetched from `mollie_record` if needed.
+5. **Detect any `amount_charged_back` change** — Not just increases. This ensures reversals are also detected and `reversed_at` is populated.
+6. **Add `on_mollie_chargeback_reversed` hook** — Reversed chargebacks are a materially different business event (money returned to merchant). Host apps that suspend accounts on chargeback need to know when to reinstate.
+
+## Acceptance Criteria
+
+- [ ] Migration creates `mollie_pay_chargebacks` table with correct schema
+- [ ] `MolliePay::Chargeback` model with `belongs_to :payment`, `mollie_id` uniqueness
+- [ ] `Payment` has `has_many :chargebacks, dependent: :destroy`
+- [ ] `Chargeback.sync_for_payment(payment)` fetches from Mollie API and upserts
+- [ ] `Payment.record_from_mollie` detects `amount_charged_back` changes and triggers sync
+- [ ] `on_mollie_chargeback_received(chargeback)` fires on Billable owner for new chargebacks
+- [ ] `on_mollie_chargeback_reversed(chargeback)` fires when `reversed_at` becomes non-nil
+- [ ] Idempotent — same chargeback processed twice doesn't create duplicates
+- [ ] `RecordNotUnique` rescue handles concurrent INSERT race
+- [ ] `reversed?` predicate on Chargeback
+- [ ] Test fixtures for chargebacks
+- [ ] Test stubs in `TestHelper` for chargeback scenarios
+- [ ] Chargeback detection tests in Payment model tests
+- [ ] AGENTS.md updated with Chargeback in architecture diagram and hooks list
+
+## Dependencies & Risks
+
+- **Mollie API surface:** `mollie-api-ruby` must expose chargeback listing on payment objects. Need to verify `payment.chargebacks` returns the expected data structure.
+- **Retry edge case:** If payment updates but chargeback sync fails mid-way, some chargebacks may be created while others aren't. The next webhook retry will re-detect the change and re-sync, so this is self-healing.
+
+## Sources & References
+
+- GitHub issue: #47
+- Refund model (template): `app/models/mollie_pay/refund.rb`
+- Payment model: `app/models/mollie_pay/payment.rb:25-58`
+- Billable concern hooks: `app/models/mollie_pay/billable.rb:122-133`
+- ProcessWebhookJob: `app/jobs/mollie_pay/process_webhook_job.rb`
+- Amount tracking migration: `db/migrate/20260317194501_add_amount_tracking_to_mollie_pay_payments.rb`

--- a/docs/solutions/integration-issues/mollie-chargeback-model-api-discovery.md
+++ b/docs/solutions/integration-issues/mollie-chargeback-model-api-discovery.md
@@ -1,0 +1,203 @@
+---
+title: "Implement Chargeback model with correct Mollie webhook detection and SDK compatibility"
+category: integration-issues
+date: 2026-03-22
+tags:
+  - chargebacks
+  - webhooks
+  - mollie-api
+  - sdk-compatibility
+  - payment-lifecycle
+  - record-not-unique
+  - test-fixtures
+severity: high
+components:
+  - Payment model
+  - Chargeback model
+  - Billable concern
+  - TestHelper
+related:
+  - docs/plans/2026-03-21-001-feat-chargeback-model-webhook-detection-plan.md
+  - "GitHub issue #47"
+  - "GitHub PR #58"
+---
+
+# Chargeback Model: Mollie API Discovery and SDK Workarounds
+
+## Problem
+
+Chargebacks were completely invisible in the mollie_pay engine. Mollie does
+NOT send separate chargeback webhooks — chargebacks arrive embedded in the
+payment object via `tr_` webhooks, with `amountChargedBack` changing while
+payment status stays "paid". The existing `previous_status` detection pattern
+was blind to this. Additionally, the `mollie-api-ruby` SDK does not expose
+all API fields, and its test fixtures don't match real API responses.
+
+## Root Cause
+
+Three interacting problems:
+
+1. **No dedicated chargeback webhook.** Detection requires comparing
+   `amount_charged_back` before and after updating the payment record — the
+   `previous_status` pattern does not apply.
+
+2. **Undocumented SDK gaps.** The Mollie API returns chargeback `reason` as
+   a nested object (`{"code": "AM04", "description": "Insufficient funds"}`),
+   but `mollie-api-ruby`'s `Chargeback` class has no `attr_accessor :reason`.
+   The data is only accessible via `mc.attributes["reason"]` because
+   `Mollie::Base` stores the full parsed response hash.
+
+3. **SDK key conversion affects fixtures.** The gem's `Util.nested_underscore_keys`
+   converts all JSON keys from camelCase to snake_case. Test fixtures must use
+   camelCase (matching the real API), not snake_case. The gem's own test fixture
+   (`get_embedded_resources.json`) uses snake_case and lacks `reason` — it does
+   not match current live API behavior.
+
+## Solution
+
+### 1. Amount-based detection in Payment.record_from_mollie
+
+```ruby
+previous_amount_charged_back = payment.amount_charged_back
+payment.update!(...)
+Chargeback.sync_for_payment(payment) if payment.amount_charged_back != previous_amount_charged_back
+```
+
+### 2. Reason extraction via raw attributes hash
+
+The SDK stores all parsed response data in `@attributes`, even for fields
+without `attr_accessor`. Access `reason` through the hash:
+
+```ruby
+def self.extract_reason(mollie_chargeback)
+  reason = (mollie_chargeback.try(:attributes) || {})["reason"]
+  return nil if reason.nil?
+
+  if reason.is_a?(Hash)
+    description = reason["description"]
+    code        = reason["code"]
+    code ? "#{description} (#{code})" : description
+  else
+    reason.to_s
+  end
+end
+```
+
+### 3. Per-chargeback RecordNotUnique with deferred hook dispatch
+
+The initial implementation wrapped `rescue RecordNotUnique` + `retry` around
+the entire sync loop — this created an infinite loop risk and re-fired hooks
+for already-processed chargebacks. Fix: rescue inside the loop with `find_by!`
+fallback, and accumulate events for dispatch after all records are persisted.
+
+```ruby
+def self.sync_for_payment(payment)
+  mollie_chargebacks = payment.mollie_record.chargebacks
+  return if mollie_chargebacks.blank?
+
+  billable = payment.customer.owner
+  events = []
+
+  mollie_chargebacks.each do |mc|
+    chargeback = find_or_initialize_by(mollie_id: mc.id)
+    was_new = chargeback.new_record?
+    was_reversed = chargeback.reversed_at
+
+    chargeback.update!(
+      payment:           payment,
+      amount:            mollie_value_to_cents(mc.amount),
+      currency:          mc.amount.currency,
+      reason:            extract_reason(mc),
+      created_at_mollie: mc.created_at,
+      reversed_at:       mc.reversed_at
+    )
+
+    if was_new
+      events << [ :received, chargeback ]
+    elsif chargeback.reversed_at.present? && was_reversed.nil?
+      events << [ :reversed, chargeback ]
+    end
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(mollie_id: mc.id)
+  end
+
+  events.each do |type, chargeback|
+    case type
+    when :received then billable.on_mollie_chargeback_received(chargeback)
+    when :reversed then billable.on_mollie_chargeback_reversed(chargeback)
+    end
+  end
+end
+```
+
+### 4. Test fixtures must match real API responses
+
+The Mollie API returns camelCase keys. The SDK converts them to snake_case
+internally. Fixtures should use camelCase:
+
+```json
+{
+  "resource": "chargeback",
+  "id": "chb_ls7ahg",
+  "amount": { "value": "10.00", "currency": "EUR" },
+  "createdAt": "2026-01-03T13:20:37+00:00",
+  "reason": { "code": "AM04", "description": "Insufficient funds" },
+  "paymentId": "tr_test1234AB",
+  "settlementAmount": { "value": "-10.00", "currency": "EUR" }
+}
+```
+
+**Do not** copy the gem's own test fixtures as ground truth — they may use
+snake_case keys and lack fields present in the real API.
+
+## Investigation Steps
+
+1. Checked the Mollie API docs and confirmed no separate chargeback webhook exists
+2. Implemented amount_charged_back comparison in `Payment.record_from_mollie`
+3. Built `Chargeback.sync_for_payment` following the Refund model pattern
+4. Code review caught the `rescue RecordNotUnique` + `retry` infinite loop risk
+5. Discovered SDK doesn't expose `reason` — verified by fetching live API data
+   from `GET /v2/payments/{id}/chargebacks/{id}` which returned
+   `"reason": {"code": "AM04", "description": "Insufficient funds"}`
+6. Found that `Mollie::Base#attributes` stores the full response hash
+7. Discovered SDK converts camelCase → snake_case via `Util.nested_underscore_keys`
+8. Updated fixtures to use camelCase matching real API responses
+
+## Prevention
+
+### When adding new Mollie resource models
+
+1. **Always fetch live API data first.** Before designing a model, call the real
+   API and inspect the raw JSON. Don't rely solely on SDK class definitions or
+   gem test fixtures.
+
+2. **Check `mc.attributes` for hidden fields.** The SDK may not expose all API
+   fields via `attr_accessor`. The raw `attributes` hash is the complete picture.
+
+3. **Use camelCase in JSON test fixtures.** The SDK handles the conversion.
+   Snake_case fixtures skip the conversion path and can mask bugs.
+
+4. **Classify the detection pattern.** Not all Mollie events use status transitions.
+   Ask: "What field(s) change when this event occurs?" For chargebacks it's
+   `amount_charged_back`, not `status`.
+
+### When using RecordNotUnique rescue
+
+1. **Never wrap an entire loop in `rescue RecordNotUnique` + `retry`.** This
+   re-processes already-handled items and can loop infinitely.
+
+2. **Rescue per-item with `find_by!` fallback.** Matches the existing Payment
+   and Refund patterns in this codebase.
+
+3. **Separate persistence from hook dispatch.** Accumulate events during the
+   persistence loop, dispatch after all records are saved. This prevents lost
+   notifications on partial failure.
+
+## Related
+
+- [Plan: Chargeback model](../../plans/2026-03-21-001-feat-chargeback-model-webhook-detection-plan.md)
+- GitHub issue: #47
+- GitHub PR: #58
+- Refund model (`app/models/mollie_pay/refund.rb`) — template for the Chargeback pattern
+- `Mollie::Base#attributes` — raw response hash in mollie-api-ruby
+- `Mollie::Util.nested_underscore_keys` — camelCase → snake_case conversion

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -17,10 +17,11 @@ POST /mollie_pay/webhooks              (from Mollie)
   → head :ok                            (respond immediately)
 
 ProcessWebhookJob:
-  → route by ID prefix (tr_ → Payment, sub_ → Subscription, re_ → Refund)
+  → route by ID prefix (tr_ → Payment, sub_ → Subscription, re_ → Refund, stl_ → Settlement)
   → fetch full object from Mollie API
   → upsert local record via record_from_mollie
-  → fire on_mollie_* hook on billable (only on status transitions)
+  → fire on_mollie_* hook on billable (only on actual state changes)
+  → detect chargebacks via amount_charged_back comparison (see below)
 ```
 
 No event model, no mutable state. The controller validates and enqueues. The job
@@ -33,17 +34,47 @@ retries with polynomial backoff (up to 5 attempts). Resources not found on Molli
 
 No signature verification is needed. Mollie's webhook pattern sends only an
 `id` parameter, which MolliePay validates against the format
-`(tr|sub|re)_[a-zA-Z0-9]+` and then fetches directly from the Mollie API.
+`(tr|sub|re|stl)_[a-zA-Z0-9]+` and then fetches directly from the Mollie API.
 The API key is the verification — only your key can fetch your objects.
+
+## Chargeback detection
+
+Mollie does **not** send separate chargeback webhooks. Chargebacks arrive via
+the normal payment webhook (`tr_` prefix) — the payment status stays `"paid"`,
+only `amountChargedBack` changes.
+
+Detection works by comparing `amount_charged_back` before and after the payment
+update in `Payment.record_from_mollie`. When the amount changes,
+`Chargeback.sync_for_payment` fetches individual chargebacks from the Mollie
+API and upserts them locally.
+
+```
+Payment webhook arrives (tr_xxx)
+  → Payment.record_from_mollie
+    → captures previous amount_charged_back
+    → updates payment record
+    → if amount_charged_back changed:
+        → Chargeback.sync_for_payment(payment)
+          → fetches chargebacks from Mollie API
+          → upserts each chargeback (find_or_initialize_by mollie_id)
+          → fires on_mollie_chargeback_received for new chargebacks
+          → fires on_mollie_chargeback_reversed when reversed_at is set
+```
+
+Hooks are dispatched **after** all chargeback records are persisted, preventing
+lost notifications on partial failure.
 
 ## Idempotency
 
-Hooks fire **only on actual status transitions**. If Mollie sends the same
-webhook multiple times (which it does routinely), the local record is updated
-but hooks are not re-triggered. As a best practice, implement your `on_mollie_*`
-callbacks **idempotently** — they are safe for side effects (send emails,
-provision access, update billing state) but should handle the rare case of
-being called more than once for the same transition.
+Hooks fire **only on actual state changes**. For most models this means status
+transitions. For chargebacks, it means new records (`new_record?` before save)
+or newly reversed chargebacks (`reversed_at` changing from nil to a value).
+
+If Mollie sends the same webhook multiple times (which it does routinely), the
+local record is updated but hooks are not re-triggered. As a best practice,
+implement your `on_mollie_*` callbacks **idempotently** — they are safe for
+side effects (send emails, provision access, update billing state) but should
+handle the rare case of being called more than once for the same transition.
 
 Transition timestamps (`paid_at`, `canceled_at`, `failed_at`, `expired_at`,
 `refunded_at`, `mandated_at`) are set once when the transition is first

--- a/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
+++ b/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
@@ -32,6 +32,8 @@
           "value": "10.00",
           "currency": "EUR"
         },
+        "reason": "Onvoldoende saldo",
+        "reasonCode": "AM04",
         "created_at": "2026-01-03T13:20:37+00:00",
         "payment_id": "tr_test1234AB",
         "settlement_amount": {

--- a/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
+++ b/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
@@ -32,11 +32,13 @@
           "value": "10.00",
           "currency": "EUR"
         },
-        "reason": "Onvoldoende saldo",
-        "reasonCode": "AM04",
-        "created_at": "2026-01-03T13:20:37+00:00",
-        "payment_id": "tr_test1234AB",
-        "settlement_amount": {
+        "createdAt": "2026-01-03T13:20:37+00:00",
+        "reason": {
+          "code": "AM04",
+          "description": "Insufficient funds"
+        },
+        "paymentId": "tr_test1234AB",
+        "settlementAmount": {
           "value": "-10.00",
           "currency": "EUR"
         },

--- a/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
+++ b/lib/mollie_pay/test_fixtures/payment_with_chargebacks.json
@@ -1,0 +1,68 @@
+{
+  "resource": "payment",
+  "id": "tr_test1234AB",
+  "mode": "test",
+  "createdAt": "2026-03-15T12:00:00+00:00",
+  "amount": {
+    "value": "10.00",
+    "currency": "EUR"
+  },
+  "description": "Test payment",
+  "method": null,
+  "metadata": null,
+  "status": "paid",
+  "isCancelable": false,
+  "locale": "nl_NL",
+  "expiresAt": "2026-03-15T12:15:00+00:00",
+  "profileId": "pfl_TestProfile",
+  "sequenceType": "oneoff",
+  "redirectUrl": "https://example.com/return",
+  "webhookUrl": "https://example.com/mollie_pay/webhooks",
+  "customerId": "cst_test1234AB",
+  "amountChargedBack": {
+    "value": "10.00",
+    "currency": "EUR"
+  },
+  "_embedded": {
+    "chargebacks": [
+      {
+        "resource": "chargeback",
+        "id": "chb_ls7ahg",
+        "amount": {
+          "value": "10.00",
+          "currency": "EUR"
+        },
+        "created_at": "2026-01-03T13:20:37+00:00",
+        "payment_id": "tr_test1234AB",
+        "settlement_amount": {
+          "value": "-10.00",
+          "currency": "EUR"
+        },
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/payments/tr_test1234AB/chargebacks/chb_ls7ahg",
+            "type": "application/hal+json"
+          },
+          "payment": {
+            "href": "https://api.mollie.com/v2/payments/tr_test1234AB",
+            "type": "application/hal+json"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/payments/tr_test1234AB",
+      "type": "application/hal+json"
+    },
+    "checkout": {
+      "href": "https://www.mollie.com/payscreen/select-method/test1234AB",
+      "type": "text/html"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/v2/payments-api/get-payment",
+      "type": "text/html"
+    }
+  }
+}

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -250,6 +250,23 @@ module MolliePay
       WebMock.reset!
     end
 
+    # Stub GET /v2/payments/:id with embedded chargebacks for chargeback
+    # detection tests. Uses the payment_with_chargebacks fixture which
+    # includes _embedded.chargebacks matching the Mollie API structure.
+    #
+    #   webmock_mollie_payment_get_with_chargebacks("tr_abc123") do
+    #     MolliePay::ProcessWebhookJob.perform_now("tr_abc123")
+    #   end
+    #
+    def webmock_mollie_payment_get_with_chargebacks(payment_id, **overrides)
+      body = mollie_fixture("payment_with_chargebacks", id: payment_id, **overrides)
+      stub_request(:get, "#{MOLLIE_API_BASE}/payments/#{payment_id}")
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/hal+json" })
+      yield
+    ensure
+      WebMock.reset!
+    end
+
     private
 
     # Load a JSON fixture file and merge in overrides.

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_21_000001) do
+  create_table "mollie_pay_chargebacks", force: :cascade do |t|
+    t.integer "amount", null: false
+    t.datetime "created_at", null: false
+    t.datetime "created_at_mollie"
+    t.string "currency", default: "EUR", null: false
+    t.string "mollie_id", null: false
+    t.integer "payment_id", null: false
+    t.string "reason"
+    t.datetime "reversed_at"
+    t.datetime "updated_at", null: false
+    t.index ["mollie_id"], name: "index_mollie_pay_chargebacks_on_mollie_id", unique: true
+    t.index ["payment_id"], name: "index_mollie_pay_chargebacks_on_payment_id"
+  end
+
   create_table "mollie_pay_customers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "mollie_id", null: false
@@ -97,6 +111,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_120000) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "mollie_pay_chargebacks", "mollie_pay_payments", column: "payment_id"
   add_foreign_key "mollie_pay_mandates", "mollie_pay_customers", column: "customer_id"
   add_foreign_key "mollie_pay_payments", "mollie_pay_customers", column: "customer_id"
   add_foreign_key "mollie_pay_payments", "mollie_pay_subscriptions", column: "subscription_id"

--- a/test/fixtures/mollie_pay/chargebacks.yml
+++ b/test/fixtures/mollie_pay/chargebacks.yml
@@ -1,0 +1,7 @@
+acme_chargeback:
+  payment: acme_first
+  mollie_id: chb_chargeback123
+  amount: 500
+  currency: EUR
+  reason: Chargeback received
+  created_at_mollie: <%= 2.days.ago %>

--- a/test/fixtures/mollie_pay/chargebacks.yml
+++ b/test/fixtures/mollie_pay/chargebacks.yml
@@ -3,5 +3,4 @@ acme_chargeback:
   mollie_id: chb_chargeback123
   amount: 500
   currency: EUR
-  reason: Chargeback received
   created_at_mollie: <%= 2.days.ago %>

--- a/test/models/mollie_pay/chargeback_test.rb
+++ b/test/models/mollie_pay/chargeback_test.rb
@@ -187,7 +187,7 @@ module MolliePay
       assert_equal "EUR", chargeback.currency
       assert_equal payment, chargeback.payment
       assert_not_nil chargeback.created_at_mollie
-      assert_equal "Onvoldoende saldo (AM04)", chargeback.reason
+      assert_equal "Insufficient funds (AM04)", chargeback.reason
       assert_not_nil hook_called_with
       assert_equal chargeback, hook_called_with
     end

--- a/test/models/mollie_pay/chargeback_test.rb
+++ b/test/models/mollie_pay/chargeback_test.rb
@@ -167,6 +167,30 @@ module MolliePay
       end
     end
 
+    test "sync_for_payment works with real Mollie SDK objects via WebMock" do
+      customer = mollie_pay_customers(:acme)
+      payment = mollie_pay_payments(:acme_oneoff)
+
+      hook_called_with = nil
+      owner = payment.customer.owner
+      owner.define_singleton_method(:on_mollie_chargeback_received) { |cb| hook_called_with = cb }
+
+      webmock_mollie_payment_get_with_chargebacks(payment.mollie_id, customer_id: customer.mollie_id) do
+        # Simulate what happens when Payment.record_from_mollie detects a chargeback
+        mollie_payment = Mollie::Payment.get(payment.mollie_id)
+        Chargeback.sync_for_payment(payment)
+      end
+
+      chargeback = Chargeback.find_by(mollie_id: "chb_ls7ahg")
+      assert_not_nil chargeback
+      assert_equal 1000, chargeback.amount
+      assert_equal "EUR", chargeback.currency
+      assert_equal payment, chargeback.payment
+      assert_not_nil chargeback.created_at_mollie
+      assert_not_nil hook_called_with
+      assert_equal chargeback, hook_called_with
+    end
+
     test "amount_decimal converts cents" do
       chargeback = mollie_pay_chargebacks(:acme_chargeback)
       assert_equal 5.0, chargeback.amount_decimal
@@ -180,12 +204,11 @@ module MolliePay
 
     private
 
-      def stub_mollie_chargeback(id:, amount_value:, amount_currency:, reason: nil, created_at: nil, reversed_at: nil)
+      def stub_mollie_chargeback(id:, amount_value:, amount_currency:, created_at: nil, reversed_at: nil)
         amount = OpenStruct.new(value: amount_value, currency: amount_currency)
         OpenStruct.new(
           id:          id,
           amount:      amount,
-          reason:      reason,
           created_at:  created_at,
           reversed_at: reversed_at
         )

--- a/test/models/mollie_pay/chargeback_test.rb
+++ b/test/models/mollie_pay/chargeback_test.rb
@@ -1,0 +1,194 @@
+require "test_helper"
+
+module MolliePay
+  class ChargebackTest < ActiveSupport::TestCase
+    test "reversed? reflects reversed_at" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      assert_not chargeback.reversed?
+
+      chargeback.reversed_at = Time.current
+      assert chargeback.reversed?
+    end
+
+    test "requires positive amount" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      chargeback.amount = 0
+      assert_not chargeback.valid?
+    end
+
+    test "requires mollie_id" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      chargeback.mollie_id = nil
+      assert_not chargeback.valid?
+    end
+
+    test "requires unique mollie_id" do
+      existing = mollie_pay_chargebacks(:acme_chargeback)
+      duplicate = Chargeback.new(
+        payment: existing.payment,
+        mollie_id: existing.mollie_id,
+        amount: 500,
+        currency: "EUR"
+      )
+      assert_not duplicate.valid?
+    end
+
+    test "belongs to payment" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      assert_equal mollie_pay_payments(:acme_first), chargeback.payment
+    end
+
+    test "sync_for_payment creates new chargeback from Mollie data" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_chargebacks = [
+        stub_mollie_chargeback(id: "chb_new123", amount_value: "10.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks)
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+      end
+
+      chargeback = Chargeback.find_by(mollie_id: "chb_new123")
+      assert_not_nil chargeback
+      assert_equal 1000, chargeback.amount
+      assert_equal "EUR", chargeback.currency
+      assert_equal payment, chargeback.payment
+    end
+
+    test "sync_for_payment is idempotent" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_chargebacks = [
+        stub_mollie_chargeback(id: "chb_idem123", amount_value: "5.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks)
+
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+        assert_equal 1, Chargeback.where(mollie_id: "chb_idem123").count
+
+        Chargeback.sync_for_payment(payment)
+        assert_equal 1, Chargeback.where(mollie_id: "chb_idem123").count
+      end
+    end
+
+    test "sync_for_payment fires on_mollie_chargeback_received for new chargebacks" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_chargebacks = [
+        stub_mollie_chargeback(id: "chb_hook123", amount_value: "10.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks)
+      hook_called = false
+      owner = payment.customer.owner
+      owner.define_singleton_method(:on_mollie_chargeback_received) { |_cb| hook_called = true }
+
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+      end
+
+      assert hook_called, "on_mollie_chargeback_received should have been called"
+    end
+
+    test "sync_for_payment does not fire hook for already processed chargebacks" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_chargebacks = [
+        stub_mollie_chargeback(id: "chb_nodup123", amount_value: "10.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks)
+      hook_count = 0
+      owner = payment.customer.owner
+      owner.define_singleton_method(:on_mollie_chargeback_received) { |_cb| hook_count += 1 }
+
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+        Chargeback.sync_for_payment(payment)
+      end
+
+      assert_equal 1, hook_count, "Hook should fire only once for the same chargeback"
+    end
+
+    test "sync_for_payment fires on_mollie_chargeback_reversed when reversed_at is set" do
+      payment = mollie_pay_payments(:acme_oneoff)
+
+      # First sync: create chargeback without reversal
+      mollie_chargebacks_initial = [
+        stub_mollie_chargeback(id: "chb_rev123", amount_value: "10.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks_initial)
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+      end
+
+      # Second sync: chargeback now has reversed_at
+      reversed_time = Time.current
+      mollie_chargebacks_reversed = [
+        stub_mollie_chargeback(id: "chb_rev123", amount_value: "10.00", amount_currency: "EUR", reversed_at: reversed_time)
+      ]
+
+      reversed_hook_called = false
+      owner = payment.customer.owner
+      owner.define_singleton_method(:on_mollie_chargeback_reversed) { |_cb| reversed_hook_called = true }
+
+      mollie_payment_record_reversed = OpenStruct.new(chargebacks: mollie_chargebacks_reversed)
+      payment.stub(:mollie_record, mollie_payment_record_reversed) do
+        Chargeback.sync_for_payment(payment)
+      end
+
+      assert reversed_hook_called, "on_mollie_chargeback_reversed should have been called"
+      assert Chargeback.find_by(mollie_id: "chb_rev123").reversed?
+    end
+
+    test "sync_for_payment handles multiple chargebacks" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_chargebacks = [
+        stub_mollie_chargeback(id: "chb_multi1", amount_value: "5.00", amount_currency: "EUR"),
+        stub_mollie_chargeback(id: "chb_multi2", amount_value: "10.00", amount_currency: "EUR")
+      ]
+
+      mollie_payment_record = OpenStruct.new(chargebacks: mollie_chargebacks)
+      payment.stub(:mollie_record, mollie_payment_record) do
+        Chargeback.sync_for_payment(payment)
+      end
+
+      assert Chargeback.exists?(mollie_id: "chb_multi1")
+      assert Chargeback.exists?(mollie_id: "chb_multi2")
+    end
+
+    test "sync_for_payment does nothing when no chargebacks" do
+      payment = mollie_pay_payments(:acme_oneoff)
+      mollie_payment_record = OpenStruct.new(chargebacks: [])
+
+      payment.stub(:mollie_record, mollie_payment_record) do
+        assert_nothing_raised { Chargeback.sync_for_payment(payment) }
+      end
+    end
+
+    test "amount_decimal converts cents" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      assert_equal 5.0, chargeback.amount_decimal
+    end
+
+    test "mollie_amount returns correct hash" do
+      chargeback = mollie_pay_chargebacks(:acme_chargeback)
+      expected = { currency: "EUR", value: "5.00" }
+      assert_equal expected, chargeback.mollie_amount
+    end
+
+    private
+
+      def stub_mollie_chargeback(id:, amount_value:, amount_currency:, reason: nil, created_at: nil, reversed_at: nil)
+        amount = OpenStruct.new(value: amount_value, currency: amount_currency)
+        OpenStruct.new(
+          id:          id,
+          amount:      amount,
+          reason:      reason,
+          created_at:  created_at,
+          reversed_at: reversed_at
+        )
+      end
+  end
+end

--- a/test/models/mollie_pay/chargeback_test.rb
+++ b/test/models/mollie_pay/chargeback_test.rb
@@ -187,6 +187,7 @@ module MolliePay
       assert_equal "EUR", chargeback.currency
       assert_equal payment, chargeback.payment
       assert_not_nil chargeback.created_at_mollie
+      assert_equal "Onvoldoende saldo (AM04)", chargeback.reason
       assert_not_nil hook_called_with
       assert_equal chargeback, hook_called_with
     end

--- a/test/models/mollie_pay/payment_test.rb
+++ b/test/models/mollie_pay/payment_test.rb
@@ -156,12 +156,14 @@ module MolliePay
         amount_charged_back: OpenStruct.new(value: "5.00", currency: "EUR")
       )
 
-      payment = Payment.record_from_mollie(mollie_payment)
+      Chargeback.stub(:sync_for_payment, nil) do
+        payment = Payment.record_from_mollie(mollie_payment)
 
-      assert_equal 1000, payment.amount_refunded
-      assert_equal 9000, payment.amount_remaining
-      assert_equal 10000, payment.amount_captured
-      assert_equal 500, payment.amount_charged_back
+        assert_equal 1000, payment.amount_refunded
+        assert_equal 9000, payment.amount_remaining
+        assert_equal 10000, payment.amount_captured
+        assert_equal 500, payment.amount_charged_back
+      end
     end
 
     test "record_from_mollie preserves amount tracking when Mollie omits fields" do
@@ -183,6 +185,51 @@ module MolliePay
       assert_nil existing.amount_remaining
       assert_equal 0, existing.amount_captured
       assert_equal 0, existing.amount_charged_back
+    end
+
+    test "record_from_mollie triggers chargeback sync when amount_charged_back changes" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_payments(:acme_first)
+      assert_equal 0, existing.amount_charged_back
+
+      mollie_payment = stub_mollie_payment(
+        id:                  existing.mollie_id,
+        status:              "paid",
+        customer_id:         customer.mollie_id,
+        sequence_type:       "first",
+        amount_value:        "10.00",
+        amount_currency:     "EUR",
+        amount_charged_back: OpenStruct.new(value: "5.00", currency: "EUR")
+      )
+
+      sync_called = false
+      Chargeback.stub(:sync_for_payment, ->(_payment) { sync_called = true }) do
+        Payment.record_from_mollie(mollie_payment)
+      end
+
+      assert sync_called, "Chargeback.sync_for_payment should be called when amount_charged_back changes"
+      assert_equal 500, existing.reload.amount_charged_back
+    end
+
+    test "record_from_mollie does not trigger chargeback sync when amount_charged_back unchanged" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_payments(:acme_first)
+
+      mollie_payment = stub_mollie_payment(
+        id:              existing.mollie_id,
+        status:          "paid",
+        customer_id:     customer.mollie_id,
+        sequence_type:   "first",
+        amount_value:    "10.00",
+        amount_currency: "EUR"
+      )
+
+      sync_called = false
+      Chargeback.stub(:sync_for_payment, ->(_payment) { sync_called = true }) do
+        Payment.record_from_mollie(mollie_payment)
+      end
+
+      assert_not sync_called, "Chargeback.sync_for_payment should not be called when amount_charged_back is unchanged"
     end
 
     test "record_from_mollie skips notify_billable when status unchanged" do


### PR DESCRIPTION
## Summary
- New `MolliePay::Chargeback` model tracking individual chargebacks from Mollie
- Detection via `amount_charged_back` comparison in `Payment.record_from_mollie` (chargebacks arrive via `tr_` payment webhooks, not separate webhooks)
- `Chargeback.sync_for_payment` fetches all chargebacks from Mollie API and upserts idempotently
- `on_mollie_chargeback_received` and `on_mollie_chargeback_reversed` hooks on Billable
- `RecordNotUnique` rescue per-chargeback with `find_by!` fallback (matches Refund pattern)
- Events dispatched after all records persisted (prevents lost notifications on partial failure)
- Reason extracted from Mollie API via `mc.attributes["reason"]` — SDK doesn't expose it via `attr_accessor` but the API returns `{"code": "AM04", "description": "Insufficient funds"}`
- JSON test fixtures use camelCase matching real Mollie API responses, verified against live data
- Solution documented in `docs/solutions/` for future reference

## Key Design Decisions
- **No separate webhook routing** — Mollie embeds chargebacks in payment webhooks (`tr_` prefix), so no changes to `WebhooksController` or `ProcessWebhookJob`
- **No status column** — chargebacks don't have Mollie status transitions; `reversed_at` serves as implicit status
- **Amount comparison, not status comparison** — detection uses `amount_charged_back` delta, not `previous_status` pattern
- **Reason via raw attributes** — `mollie-api-ruby` doesn't have `attr_accessor :reason` on `Chargeback`, but the API returns it as an object with `code` and `description`; accessed via `mc.attributes["reason"]`

## Testing
- 15 chargeback model tests (sync, idempotency, hooks, reversal, multiple chargebacks, WebMock integration)
- 2 payment model tests (chargeback detection trigger/no-trigger)
- WebMock integration test parses through real Mollie SDK pipeline, asserts reason extraction
- All 151 tests pass, 0 rubocop offenses

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this is a library gem, not a deployed service. Host apps should monitor their `on_mollie_chargeback_received` callbacks.

Closes #47