### PR TITLE
feat(methods): Add payment methods listing (read-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ Public methods:
 - `mollie_subscription(name: "default")`
 - `mollie_mandate`
 - `mollie_payments` → `has_many :through` association (supports `includes`, `joins`, etc.)
+- `mollie_payment_methods(**options)` → delegates to `MolliePay.payment_methods`
 
 **Named subscriptions:** All subscription methods accept `name:` with a default
 of `"default"`. This allows multiple concurrent subscriptions per customer

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -117,6 +117,10 @@ module MolliePay
       mollie_mandates.valid_status.first
     end
 
+    def mollie_payment_methods(**options)
+      MolliePay.payment_methods(**options)
+    end
+
     # === Hooks — override these in your model ===
 
     def on_mollie_payment_paid(payment)             ; end

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@
 | `mollie_pay_subscriptions` | `mollie_id`, `status`, `amount`, `interval` | Recurring billing agreements |
 | `mollie_pay_payments` | `mollie_id`, `status`, `amount`, `sequence_type` | Individual payment records |
 | `mollie_pay_refunds` | `mollie_id`, `status`, `amount` | Refunds against payments |
+| `mollie_pay_chargebacks` | `mollie_id`, `amount`, `reason` | Chargebacks against payments |
 
 Only fields needed for business logic and state queries are stored locally.
 Display data lives in Mollie and is fetched via `mollie_record`.
@@ -19,7 +20,8 @@ Display data lives in Mollie and is fetched via `mollie_record`.
 Owner (your model)
   └── Customer (1:1, polymorphic)
         ├── Payments (1:N)
-        │     └── Refunds (1:N)
+        │     ├── Refunds (1:N)
+        │     └── Chargebacks (1:N)
         ├── Subscriptions (1:N)
         │     └── Payments (1:N, optional)
         └── Mandates (1:N)
@@ -95,6 +97,66 @@ payment.mollie_amount   # => { currency: "EUR", value: "25.00" } (Mollie format)
 ```
 
 The same methods are available on `Subscription` and `Refund`.
+
+## Payment methods
+
+List available payment methods from the Mollie API. These are fetched live —
+no local model or migration is involved.
+
+```ruby
+MolliePay.payment_methods                                   # all enabled methods
+MolliePay.payment_methods(amount: 1000)                     # filtered by amount (cents)
+MolliePay.payment_methods(amount: 1000, currency: "USD")    # with currency override
+MolliePay.payment_methods(locale: "nl_NL")                  # localized descriptions
+MolliePay.payment_methods(include: "pricing")               # include pricing details
+
+MolliePay.payment_method("ideal")                           # single method details
+MolliePay.payment_method("creditcard", locale: "nl_NL")     # with locale
+```
+
+A convenience method is available on Billable:
+
+```ruby
+organization.mollie_payment_methods(amount: 2500, locale: "nl_NL")
+```
+
+Both return Mollie SDK objects (`Mollie::Method`) with `id`, `description`,
+`minimum_amount`, `maximum_amount`, `image`, and `status`.
+
+### Caching
+
+Payment methods rarely change. Cache them in your host app to avoid hitting
+the Mollie API on every checkout page load:
+
+```ruby
+# app/models/organization.rb
+def available_payment_methods(amount: nil)
+  cache_key = ["mollie_payment_methods", amount, MolliePay.configuration.currency]
+  Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+    mollie_payment_methods(amount: amount).map do |method|
+      {
+        id:          method.id,
+        description: method.description,
+        image:       method.image["svg"],
+        status:      method.status
+      }
+    end
+  end
+end
+```
+
+> **Important:** Cache the serialized data (hashes/arrays), not the
+> `Mollie::Method` objects themselves. SDK objects hold network references
+> and are not safe for cache serialization.
+
+**Cache invalidation tips:**
+
+- Use `expires_in: 1.hour` — methods change infrequently, but Mollie can
+  enable/disable methods at any time
+- Include `amount` in the cache key if you filter by amount, since different
+  amounts may yield different available methods
+- Bust the cache manually when you change payment method settings in the
+  Mollie dashboard: `Rails.cache.delete_matched("mollie_payment_methods*")`
 
 ## Errors
 

--- a/lib/mollie_pay.rb
+++ b/lib/mollie_pay.rb
@@ -5,4 +5,32 @@ require "mollie_pay/configuration"
 require "mollie_pay/engine"
 
 module MolliePay
+  # List enabled payment methods. Optionally filter by amount and currency.
+  # Returns Mollie SDK objects directly (Mollie::List of Mollie::Method).
+  #
+  #   MolliePay.payment_methods
+  #   MolliePay.payment_methods(amount: 1000, locale: "nl_NL")
+  #   MolliePay.payment_methods(amount: 1000, currency: "EUR", include: "pricing")
+  #
+  def self.payment_methods(amount: nil, currency: nil, locale: nil, **options)
+    params = options
+    if amount
+      params[:amount] = {
+        currency: currency || configuration.currency,
+        value:    format("%.2f", amount / 100.0)
+      }
+    end
+    params[:locale] = locale if locale
+    Mollie::Method.all(params)
+  end
+
+  # Get a single payment method by its ID.
+  # Returns a Mollie::Method object.
+  #
+  #   MolliePay.payment_method("ideal")
+  #   MolliePay.payment_method("creditcard", locale: "nl_NL")
+  #
+  def self.payment_method(id, **options)
+    Mollie::Method.get(id, options)
+  end
 end

--- a/test/lib/mollie_pay/payment_methods_test.rb
+++ b/test/lib/mollie_pay/payment_methods_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class MolliePay::PaymentMethodsTest < ActiveSupport::TestCase
+  test "payment_methods returns available methods" do
+    methods_list = [ stub_mollie_method("ideal", "iDEAL") ]
+    Mollie::Method.stub(:all, methods_list) do
+      result = MolliePay.payment_methods
+      assert_equal 1, result.size
+      assert_equal "ideal", result.first.id
+    end
+  end
+
+  test "payment_methods passes amount as Mollie format" do
+    called_with = nil
+    fake_all = ->(params) { called_with = params; [] }
+
+    Mollie::Method.stub(:all, fake_all) do
+      MolliePay.payment_methods(amount: 1000)
+    end
+
+    assert_equal({ currency: "EUR", value: "10.00" }, called_with[:amount])
+  end
+
+  test "payment_methods passes currency override" do
+    called_with = nil
+    fake_all = ->(params) { called_with = params; [] }
+
+    Mollie::Method.stub(:all, fake_all) do
+      MolliePay.payment_methods(amount: 500, currency: "USD")
+    end
+
+    assert_equal "USD", called_with[:amount][:currency]
+  end
+
+  test "payment_methods passes locale" do
+    called_with = nil
+    fake_all = ->(params) { called_with = params; [] }
+
+    Mollie::Method.stub(:all, fake_all) do
+      MolliePay.payment_methods(locale: "nl_NL")
+    end
+
+    assert_equal "nl_NL", called_with[:locale]
+  end
+
+  test "payment_methods does not include amount when not provided" do
+    called_with = nil
+    fake_all = ->(params) { called_with = params; [] }
+
+    Mollie::Method.stub(:all, fake_all) do
+      MolliePay.payment_methods
+    end
+
+    assert_nil called_with[:amount]
+  end
+
+  test "payment_methods forwards extra options" do
+    called_with = nil
+    fake_all = ->(params) { called_with = params; [] }
+
+    Mollie::Method.stub(:all, fake_all) do
+      MolliePay.payment_methods(include: "pricing")
+    end
+
+    assert_equal "pricing", called_with[:include]
+  end
+
+  test "payment_method returns single method by id" do
+    method = stub_mollie_method("ideal", "iDEAL")
+    Mollie::Method.stub(:get, method) do
+      result = MolliePay.payment_method("ideal")
+      assert_equal "ideal", result.id
+      assert_equal "iDEAL", result.description
+    end
+  end
+
+  test "payment_method forwards options" do
+    called_with_id = nil
+    called_with_opts = nil
+    fake_get = ->(id, opts) { called_with_id = id; called_with_opts = opts; stub_mollie_method(id, "Test") }
+
+    Mollie::Method.stub(:get, fake_get) do
+      MolliePay.payment_method("ideal", locale: "nl_NL")
+    end
+
+    assert_equal "ideal", called_with_id
+    assert_equal({ locale: "nl_NL" }, called_with_opts)
+  end
+
+  private
+
+    def stub_mollie_method(id, description)
+      OpenStruct.new(id: id, description: description, status: "activated")
+    end
+end


### PR DESCRIPTION
## Summary
- `MolliePay.payment_methods` — list enabled payment methods from Mollie API
- `MolliePay.payment_method(id)` — get single method details (e.g., `"ideal"`)
- `mollie_payment_methods` convenience method on Billable concern
- Amount passed in cents, converted to Mollie format automatically
- Supports `locale`, `currency`, and extra options like `include: "pricing"`
- Returns Mollie SDK objects directly — no local model or migration needed

## Design Decision
Payment methods are dynamic (depend on amount, currency, locale, account configuration) so they are always fetched live from the Mollie API rather than stored locally.

## Testing
- 8 tests covering: listing, amount formatting, currency override, locale, option forwarding, single method fetch
- All 159 tests pass, 0 rubocop offenses

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: read-only API wrapper, no state changes.

Closes #50