### PR TITLE
feat(subscriptions): Add subscription plan swap (upgrade/downgrade)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Public methods:
 - `mollie_pay_first(amount:, description:, redirect_url: nil, method: nil, metadata: nil)` → returns `Payment` with `checkout_url`
 - `mollie_subscribe(amount:, interval:, description:, start_date: nil, name: "default")` → returns `Subscription` (returns existing if pending/active for that name)
 - `mollie_cancel_subscription(name: "default")`
+- `mollie_swap_subscription(name: "default", amount: nil, interval: nil)` — upgrade/downgrade via Mollie PATCH
 - `mollie_update_payment(payment, description: nil, redirect_url: nil, metadata: nil)`
 - `mollie_cancel_payment(payment)` — raises `PaymentNotCancelable` if Mollie says it's not cancelable
 - `mollie_refund(payment, amount: nil)`
@@ -203,6 +204,7 @@ Event hooks (override in host model, all no-ops by default):
 - `on_mollie_refund_processed`
 - `on_mollie_chargeback_received`
 - `on_mollie_chargeback_reversed`
+- `on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)`
 
 ---
 

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -82,6 +82,38 @@ module MolliePay
       subscription.update!(status: "canceled", canceled_at: Time.current)
     end
 
+    def mollie_swap_subscription(name: "default", amount: nil, interval: nil)
+      subscription = mollie_subscriptions.where(status: Subscription::ACTIVE_STATUSES).named(name).first
+      raise MolliePay::SubscriptionNotFound, "No active subscription" unless subscription
+
+      params = {}
+      params[:amount]   = mollie_amount(amount) if amount && amount != subscription.amount
+      params[:interval] = interval              if interval && interval != subscription.interval
+      return subscription if params.empty?
+
+      previous_amount   = subscription.amount
+      previous_interval = subscription.interval
+
+      Mollie::Customer::Subscription.update(
+        subscription.mollie_id,
+        customer_id: mollie_customer.mollie_id,
+        **params
+      )
+
+      subscription.update!(
+        amount:   amount || subscription.amount,
+        interval: interval || subscription.interval
+      )
+
+      on_mollie_subscription_swapped(
+        subscription,
+        previous_amount: previous_amount,
+        previous_interval: previous_interval
+      )
+
+      subscription
+    end
+
     def mollie_update_payment(payment, description: nil, redirect_url: nil, metadata: nil)
       verify_payment_ownership!(payment)
 
@@ -161,6 +193,7 @@ module MolliePay
     def on_mollie_refund_processed(refund)          ; end
     def on_mollie_chargeback_received(chargeback)  ; end
     def on_mollie_chargeback_reversed(chargeback)  ; end
+    def on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:) ; end
 
     private
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,43 @@ end
 - Bust the cache manually when you change payment method settings in the
   Mollie dashboard: `Rails.cache.delete_matched("mollie_payment_methods*")`
 
+## Subscription plan swap (upgrade/downgrade)
+
+Change a customer's subscription amount and/or interval without canceling:
+
+```ruby
+organization.mollie_swap_subscription(amount: 4999)                           # change amount only
+organization.mollie_swap_subscription(interval: "1 year")                     # change interval only
+organization.mollie_swap_subscription(amount: 4999, interval: "1 year")       # change both
+organization.mollie_swap_subscription(name: "addon", amount: 1999)            # named subscription
+```
+
+This uses the Mollie Update Subscription API (`PATCH`) to modify the existing
+subscription in place. The change takes effect on the **next billing cycle** —
+Mollie does not calculate proration.
+
+- Returns the existing subscription unchanged if the values are already the same (no API call)
+- Raises `SubscriptionNotFound` if no active or pending subscription exists for the name
+- Fires `on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)`
+
+### Proration
+
+Mollie does not handle proration. If you need to charge the upgrade difference
+immediately, use the swap hook:
+
+```ruby
+def on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)
+  if subscription.amount > previous_amount
+    difference = subscription.amount - previous_amount
+    mollie_pay_once(
+      amount: difference,
+      description: "Plan upgrade proration",
+      redirect_url: billing_url
+    )
+  end
+end
+```
+
 ## Errors
 
 | Error | Raised when |

--- a/docs/plans/2026-03-22-001-feat-subscription-plan-swap-plan.md
+++ b/docs/plans/2026-03-22-001-feat-subscription-plan-swap-plan.md
@@ -1,0 +1,222 @@
+---
+title: "feat: Add subscription plan swap (upgrade/downgrade)"
+type: feat
+status: completed
+date: 2026-03-22
+github_issue: 66
+---
+
+# feat: Add subscription plan swap (upgrade/downgrade)
+
+## Overview
+
+Add the ability to change a customer's subscription plan — upgrading or
+downgrading by modifying the amount, interval, and/or description on an
+existing subscription. Uses the Mollie Update Subscription API (`PATCH`)
+for in-place changes. No cancel-and-recreate needed.
+
+## Problem Statement
+
+A customer on subscription plan A needs to move to plan B (different amount,
+interval, or description). Currently the only option is to cancel and
+resubscribe, which creates a gap where `mollie_subscribed?` returns `false`
+and the partial unique index blocks concurrent creation for the same name.
+
+## Proposed Solution
+
+Add `mollie_swap_subscription` to the Billable concern that PATCHes the
+existing subscription on Mollie, then updates the local record to match.
+
+### Why PATCH, not cancel-and-recreate
+
+**Verified against the live Mollie API:** The `PATCH /v2/customers/{id}/subscriptions/{id}`
+endpoint accepts `amount`, `interval`, `description`, `times`, `startDate`,
+`webhookUrl`, `mandateId`, and `metadata`. This was tested against the live API
+on 2026-03-22 — interval changes are accepted via PATCH.
+
+This eliminates the need for cancel-and-recreate, which would introduce:
+- A gap period where `mollie_subscribed?` returns `false`
+- Partial unique index conflicts
+- Partial failure scenarios (canceled but not recreated)
+- Misleading `on_mollie_subscription_canceled` hooks firing during upgrades
+
+### API Design
+
+```ruby
+# Change amount only (keeps current interval)
+org.mollie_swap_subscription(amount: 4999)
+
+# Change amount and interval
+org.mollie_swap_subscription(amount: 4999, interval: "1 year")
+
+# Named subscription
+org.mollie_swap_subscription(name: "analytics_addon", amount: 1999)
+```
+
+**Parameters:**
+- `name:` — subscription name (default: `"default"`)
+- `amount:` — new amount in cents (optional, keeps current if nil)
+- `interval:` — new interval string (optional, keeps current if nil)
+All parameters are optional except at least one of `amount` or `interval`
+must be provided (otherwise it's a no-op). Description is managed on the
+Mollie dashboard — not accepted as a parameter here, since there is no local
+`description` column and silently PATCHing Mollie without local persistence
+would be confusing for callers.
+
+### Behavior
+
+1. Find active or pending subscription for the given `name` (uses `ACTIVE_STATUSES` scope)
+2. Raise `SubscriptionNotFound` if no active/pending subscription exists
+3. Skip API call if nothing actually changed (no-op guard)
+4. PATCH the subscription on Mollie via `Mollie::Customer::Subscription.update`
+5. Update the local record with new `amount` and `interval`
+6. Fire `on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)`
+   hook on the Billable owner
+7. Return the updated subscription
+
+### No proration
+
+Mollie does not calculate proration. The new amount/interval takes effect on
+the next billing cycle. If the host app needs proration (e.g., charge the
+upgrade difference immediately), they can use the
+`on_mollie_subscription_swapped` hook to create a one-off payment via
+`mollie_pay_once` for the prorated difference.
+
+## Technical Approach
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `app/models/mollie_pay/billable.rb` | Add `mollie_swap_subscription` method |
+| `app/models/mollie_pay/billable.rb` | Add `on_mollie_subscription_swapped` hook |
+| `lib/mollie_pay/test_helper.rb` | Add `stub_mollie_subscription_update` |
+| `test/models/mollie_pay/billable_test.rb` | Tests for swap |
+| `AGENTS.md` | Document new method and hook |
+| `docs/api.md` | Document swap API and proration guidance |
+
+### No migration needed
+
+The `amount` and `interval` columns already exist on `mollie_pay_subscriptions`.
+`Subscription.record_from_mollie` already syncs both from Mollie webhooks.
+No `description` column is added — description is Mollie-side only, matching
+the existing pattern.
+
+### Implementation
+
+```ruby
+# app/models/mollie_pay/billable.rb
+
+def mollie_swap_subscription(name: "default", amount: nil, interval: nil)
+  subscription = mollie_subscriptions.where(status: Subscription::ACTIVE_STATUSES).named(name).first
+  raise MolliePay::SubscriptionNotFound, "No active subscription" unless subscription
+
+  params = {}
+  params[:amount]   = mollie_amount(amount) if amount && amount != subscription.amount
+  params[:interval] = interval              if interval && interval != subscription.interval
+  return subscription if params.empty?
+
+  previous_amount   = subscription.amount
+  previous_interval = subscription.interval
+
+  Mollie::Customer::Subscription.update(
+    subscription.mollie_id,
+    customer_id: mollie_customer.mollie_id,
+    **params
+  )
+
+  subscription.update!(
+    amount:   amount || subscription.amount,
+    interval: interval || subscription.interval
+  )
+
+  on_mollie_subscription_swapped(
+    subscription,
+    previous_amount: previous_amount,
+    previous_interval: previous_interval
+  )
+
+  subscription
+end
+```
+
+### Hook
+
+```ruby
+# New no-op hook in Billable
+def on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:) ; end
+```
+
+The hook receives the updated subscription plus the previous values, enabling
+the host app to calculate proration if needed:
+
+```ruby
+# Host app example
+def on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)
+  if subscription.amount > previous_amount
+    difference = subscription.amount - previous_amount
+    mollie_pay_once(
+      amount: difference,
+      description: "Upgrade proration",
+      redirect_url: billing_url
+    )
+  end
+end
+```
+
+### Test helper
+
+```ruby
+# lib/mollie_pay/test_helper.rb
+
+def stub_mollie_subscription_update(**overrides, &block)
+  response = fake_mollie_subscription(**overrides)
+  Mollie::Customer::Subscription.stub(:update, response, &block)
+end
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Swap to same amount/interval | No-op, returns subscription without API call |
+| No active subscription | Raises `SubscriptionNotFound` |
+| Suspended subscription | Not found (scope uses `ACTIVE_STATUSES`), raises `SubscriptionNotFound` |
+| Pending subscription | Found (included in `ACTIVE_STATUSES`), PATCH sent to Mollie |
+| Canceled subscription | Not found, raises `SubscriptionNotFound` |
+| Mollie API error | Raises Mollie error, local record unchanged |
+| Webhook arrives after swap | `record_from_mollie` syncs amount/interval from Mollie — consistent |
+| Concurrent swap requests | Last PATCH wins on Mollie side; local record updated by each caller |
+
+### Suspended subscription consideration
+
+A suspended subscription cannot be swapped because the scope only finds
+`active` subscriptions. This is intentional — a suspended subscription has
+payment issues that should be resolved before changing the plan. Document
+this limitation.
+
+## Acceptance Criteria
+
+- [ ] `mollie_swap_subscription(amount:)` updates amount on active subscription
+- [ ] `mollie_swap_subscription(interval:)` updates interval on active subscription
+- [ ] `mollie_swap_subscription(amount:, interval:)` updates both fields
+- [ ] Only changed values are sent to Mollie API (partial PATCH)
+- [ ] No-op when called with same values as current subscription
+- [ ] Swaps pending subscriptions (included in `ACTIVE_STATUSES`)
+- [ ] Raises `SubscriptionNotFound` when no active/pending subscription for name
+- [ ] Local `amount` and `interval` columns updated after successful PATCH
+- [ ] `on_mollie_subscription_swapped` hook fires with previous values
+- [ ] Named subscriptions work: `mollie_swap_subscription(name: "addon", amount: 1999)`
+- [ ] `stub_mollie_subscription_update` test helper added
+- [ ] AGENTS.md updated with new method and hook
+- [ ] docs/api.md updated with swap API and proration guidance
+
+## Sources & References
+
+- Mollie Update Subscription API: https://docs.mollie.com/reference/update-subscription
+- Mollie SDK: `Mollie::Customer::Subscription.update` (inherits from `Mollie::Base.update`)
+- Live API verification: PATCH with `interval` confirmed working on 2026-03-22
+- Named subscriptions plan: `docs/plans/2026-03-17-003-feat-named-subscriptions-plan.md`
+- Pay gem swap pattern: https://github.com/pay-rails/pay
+- Laravel Cashier proration: https://laravel.com/docs/11.x/billing
+- Existing patterns: `app/models/mollie_pay/billable.rb` (mollie_subscribe, mollie_cancel_subscription)

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -87,6 +87,17 @@ module MolliePay
       Mollie::Customer::Subscription.stub(:cancel, nil, &block)
     end
 
+    # Stub Mollie::Customer::Subscription.update.
+    #
+    #   stub_mollie_subscription_update do
+    #     @user.mollie_swap_subscription(amount: 4999)
+    #   end
+    #
+    def stub_mollie_subscription_update(**overrides, &block)
+      response = fake_mollie_subscription(**overrides)
+      Mollie::Customer::Subscription.stub(:update, response, &block)
+    end
+
     # Stub Mollie::Refund.create.
     #
     #   stub_mollie_refund_create do

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -512,6 +512,140 @@ module MolliePay
       end
     end
 
+    # === Subscription swap ===
+
+    test "mollie_swap_subscription updates amount on active subscription" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      assert_equal 2500, subscription.amount
+
+      stub_mollie_subscription_update do
+        result = @org.mollie_swap_subscription(amount: 4999)
+        assert_equal subscription, result
+      end
+
+      assert_equal 4999, subscription.reload.amount
+      assert_equal "1 month", subscription.interval
+    end
+
+    test "mollie_swap_subscription updates interval on active subscription" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+
+      stub_mollie_subscription_update do
+        @org.mollie_swap_subscription(interval: "1 year")
+      end
+
+      assert_equal "1 year", subscription.reload.interval
+      assert_equal 2500, subscription.amount
+    end
+
+    test "mollie_swap_subscription updates both amount and interval" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+
+      stub_mollie_subscription_update do
+        @org.mollie_swap_subscription(amount: 9999, interval: "1 year")
+      end
+
+      assert_equal 9999, subscription.reload.amount
+      assert_equal "1 year", subscription.interval
+    end
+
+    test "mollie_swap_subscription sends only changed values to Mollie" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      received_params = nil
+      fake_update = ->(id, **params) { received_params = params; OpenStruct.new(id: id, status: "active") }
+
+      Mollie::Customer::Subscription.stub(:update, fake_update) do
+        @org.mollie_swap_subscription(amount: 4999)
+      end
+
+      assert_equal({ currency: "EUR", value: "49.99" }, received_params[:amount])
+      assert_nil received_params[:interval]
+    end
+
+    test "mollie_swap_subscription is a no-op when nothing changed" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      api_called = false
+      fake_update = ->(*, **) { api_called = true; OpenStruct.new }
+
+      Mollie::Customer::Subscription.stub(:update, fake_update) do
+        result = @org.mollie_swap_subscription(amount: subscription.amount)
+        assert_equal subscription, result
+      end
+
+      assert_not api_called, "Should not call Mollie API when nothing changed"
+    end
+
+    test "mollie_swap_subscription raises when no active subscription" do
+      org = Organization.create!(name: "New Org", email: "new@org.nl")
+      assert_raises(MolliePay::SubscriptionNotFound) do
+        org.mollie_swap_subscription(amount: 4999)
+      end
+    end
+
+    test "mollie_swap_subscription works with named subscriptions" do
+      addon = mollie_pay_subscriptions(:acme_addon)
+      assert_equal 1000, addon.amount
+
+      stub_mollie_subscription_update do
+        @org.mollie_swap_subscription(name: "analytics_addon", amount: 1999)
+      end
+
+      assert_equal 1999, addon.reload.amount
+    end
+
+    test "mollie_swap_subscription fires on_mollie_subscription_swapped hook" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      hook_called = false
+      hook_sub = nil
+      hook_prev_amount = nil
+      hook_prev_interval = nil
+
+      @org.define_singleton_method(:on_mollie_subscription_swapped) do |sub, previous_amount:, previous_interval:|
+        hook_called = true
+        hook_sub = sub
+        hook_prev_amount = previous_amount
+        hook_prev_interval = previous_interval
+      end
+
+      stub_mollie_subscription_update do
+        @org.mollie_swap_subscription(amount: 4999, interval: "1 year")
+      end
+
+      assert hook_called, "on_mollie_subscription_swapped should have been called"
+      assert_equal subscription, hook_sub
+      assert_equal 2500, hook_prev_amount
+      assert_equal "1 month", hook_prev_interval
+    end
+
+    test "mollie_swap_subscription does not fire hook on no-op" do
+      hook_called = false
+      @org.define_singleton_method(:on_mollie_subscription_swapped) { |*, **| hook_called = true }
+
+      result = @org.mollie_swap_subscription(amount: 2500)
+
+      assert_not hook_called, "Hook should not fire when nothing changed"
+    end
+
+    test "mollie_swap_subscription finds pending subscriptions" do
+      subscription = mollie_pay_subscriptions(:acme_monthly)
+      subscription.update!(status: "pending")
+
+      stub_mollie_subscription_update do
+        result = @org.mollie_swap_subscription(amount: 4999)
+        assert_equal subscription, result
+      end
+
+      assert_equal 4999, subscription.reload.amount
+    end
+
+    test "mollie_swap_subscription does not find suspended subscriptions" do
+      mollie_pay_subscriptions(:acme_monthly).update!(status: "suspended")
+
+      assert_raises(MolliePay::SubscriptionNotFound) do
+        @org.mollie_swap_subscription(amount: 4999)
+      end
+    end
+
     # === Idempotency keys ===
 
     test "mollie_pay_once sends idempotency key to Mollie" do


### PR DESCRIPTION
## Summary
- `mollie_swap_subscription(name:, amount:, interval:)` — upgrade/downgrade an existing subscription via Mollie's Update Subscription API (PATCH)
- Uses in-place PATCH instead of cancel-and-recreate — no gap period, no partial unique index conflicts
- New `on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)` hook for host app proration logic
- Change takes effect on next billing cycle (Mollie does not prorate)
- Verified against live Mollie API: PATCH accepts interval changes on active subscriptions

## Key Design Decisions
- **PATCH, not cancel-and-recreate** — Mollie's Update Subscription endpoint accepts amount AND interval changes. Verified on live API 2026-03-22. This eliminates the gap period, unique index conflicts, and misleading cancellation hooks.
- **No proration in the gem** — Mollie doesn't handle proration. The hook provides `previous_amount` and `previous_interval` so host apps can implement their own proration strategy.
- **No `description` parameter** — There's no local `description` column; silently PATCHing Mollie without local persistence would confuse callers. Description is Mollie-dashboard-only.
- **Finds pending + active subscriptions** — Uses `ACTIVE_STATUSES` scope, consistent with `mollie_subscribe`'s idempotency check. Allows swapping before the first payment.

## Testing
- 11 new tests: amount/interval/both updates, partial PATCH, no-op guard, named subs, hook firing with previous values, pending sub swap, suspended sub rejection
- All 179 tests pass, 0 rubocop offenses

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: library gem, no deployed service.

Closes #66