### PR TITLE
feat(webhooks): Add Next-Gen Webhooks with HMAC-SHA256 signature verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,12 @@ no views, one webhook endpoint, pure business logic.
 app/
   controllers/mollie_pay/
     application_controller.rb   # inherits ActionController::Base directly
-    webhooks_controller.rb      # create only
+    webhooks_controller.rb      # classic webhooks (create only)
+    webhook_events_controller.rb # next-gen webhooks with HMAC verification
   jobs/mollie_pay/
     application_job.rb
-    process_webhook_job.rb
+    process_webhook_job.rb      # classic webhook processing
+    process_webhook_event_job.rb # next-gen event processing
   models/mollie_pay/
     application_record.rb       # shared mollie_value_to_cents
     billable.rb                 # concern included by host app model
@@ -60,6 +62,7 @@ lib/
     engine.rb
     errors.rb
     version.rb
+    webhook_signature.rb    # HMAC-SHA256 verification for next-gen webhooks
   mollie_pay.rb
 ```
 
@@ -216,11 +219,21 @@ MolliePay.configure do |config|
   config.host                  = ENV["MOLLIE_HOST"]
   config.default_redirect_path = "/payments/:id"
   config.currency              = "EUR"
+  config.webhook_signing_secret = ENV["MOLLIE_WEBHOOK_SIGNING_SECRET"]
 end
 ```
 
 The engine initializer wires `api_key` to `Mollie::Client.configure`
 automatically. No separate Mollie SDK setup is needed.
+
+**Next-Gen Webhooks:** Set `webhook_signing_secret` to enable HMAC-SHA256
+verification for the `/webhook_events` endpoint. Accepts a string or an
+array of strings (for secret rotation). If not set, events are accepted
+without verification.
+
+**Note:** `ProcessWebhookEventJob` receives event data with **camelCase**
+string keys (e.g., `event["entityId"]`, not `event["entity_id"]`), unlike
+classic webhooks where the Mollie SDK converts to snake_case.
 
 ---
 

--- a/app/controllers/mollie_pay/webhook_events_controller.rb
+++ b/app/controllers/mollie_pay/webhook_events_controller.rb
@@ -1,0 +1,39 @@
+module MolliePay
+  class WebhookEventsController < ApplicationController
+    skip_forgery_protection
+
+    def create
+      raw_body = request.raw_post
+      head :bad_request and return if raw_body.blank?
+
+      verify_signature!(raw_body)
+
+      event = JSON.parse(raw_body)
+
+      if event["id"].present? && event["type"].present?
+        ProcessWebhookEventJob.perform_later(event)
+        head :ok
+      else
+        head :unprocessable_entity
+      end
+    rescue JSON::ParserError
+      head :bad_request
+    rescue MolliePay::InvalidSignature => e
+      Rails.logger.warn("[MolliePay] Webhook signature verification failed: #{e.message}")
+      head :bad_request
+    end
+
+    private
+
+      def verify_signature!(raw_body)
+        secrets = MolliePay.configuration.webhook_signing_secrets
+        return if secrets.nil?
+
+        MolliePay::WebhookSignature.verify!(
+          raw_body,
+          request.headers["X-Mollie-Signature"],
+          secrets
+        )
+      end
+  end
+end

--- a/app/jobs/mollie_pay/process_webhook_event_job.rb
+++ b/app/jobs/mollie_pay/process_webhook_event_job.rb
@@ -1,0 +1,11 @@
+module MolliePay
+  class ProcessWebhookEventJob < ApplicationJob
+    queue_as :default
+
+    retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+    def perform(event)
+      Rails.logger.info("[MolliePay] Received webhook event: #{event['type']} (#{event['entityId']})")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 MolliePay::Engine.routes.draw do
-  resources :webhooks, only: :create
+  resources :webhooks,       only: :create
+  resources :webhook_events, only: :create
 end

--- a/docs/plans/2026-03-22-002-feat-next-gen-webhooks-hmac-verification-plan.md
+++ b/docs/plans/2026-03-22-002-feat-next-gen-webhooks-hmac-verification-plan.md
@@ -1,0 +1,397 @@
+---
+title: "feat: Next-Gen Webhooks Phase 1 — HMAC verification and event receiving"
+type: feat
+status: completed
+date: 2026-03-22
+deepened: 2026-03-22
+github_issue: 70
+origin: docs/brainstorms/2026-03-22-next-gen-webhooks-research.md
+---
+
+# feat: Next-Gen Webhooks Phase 1 — HMAC verification and event receiving
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-22
+**Agents used:** security-sentinel, kieran-rails-reviewer, architecture-strategist, code-simplicity-reviewer, learnings-researcher
+
+### Key Improvements from Deepening
+
+1. **Security:** Added explicit `sha256=` prefix validation, warn-level logging for invalid signatures, boot-time warning when no secret configured
+2. **Convention fix:** Replaced mid-method guard clause with expanded conditional (per AGENTS.md)
+3. **Simplified job:** Removed commented-out case branches and unnecessary variables — just log the event
+4. **Simplified test helper:** Removed YAGNI `entity`/`_embedded` parameter
+5. **Added `require "openssl"`** to signature module for explicit dependency
+6. **Documented architectural departure:** Full event hash as job argument (vs classic's single ID string) is intentional to avoid extra API fetch
+
+## Overview
+
+Add first-class support for receiving and verifying Mollie's Next-Gen Webhook
+events. This is the foundation that Sales Invoices (#69) and future event
+types will build on. Phase 1 focuses on **receiving and verifying** — no
+OAuth, no subscription management API. Users create webhook subscriptions
+via the Mollie Dashboard, and mollie_pay handles the incoming events with
+HMAC signature verification.
+
+(see origin: `docs/brainstorms/2026-03-22-next-gen-webhooks-research.md`)
+
+## Problem Statement
+
+Mollie's Next-Gen Webhooks deliver events (like `sales-invoice.paid`) with
+HMAC-SHA256 signed payloads. The current mollie_pay architecture only handles
+classic webhooks (resource ID in POST body, no signature). Without next-gen
+support, mollie_pay cannot receive sales invoice events, payment link events,
+or any future event types Mollie adds to this system.
+
+## Proposed Solution
+
+### New endpoint alongside classic webhooks
+
+```
+Classic: POST /mollie_pay/webhooks           → WebhooksController#create (unchanged)
+Next-gen: POST /mollie_pay/webhook_events    → WebhookEventsController#create (new)
+```
+
+Both endpoints coexist. Classic webhooks are not modified.
+
+### Configuration
+
+```ruby
+MolliePay.configure do |config|
+  config.api_key               = ENV["MOLLIE_API_KEY"]
+  config.host                  = ENV["MOLLIE_HOST"]
+  config.webhook_signing_secret = ENV["MOLLIE_WEBHOOK_SIGNING_SECRET"]
+  # For secret rotation, pass an array:
+  # config.webhook_signing_secret = [ENV["MOLLIE_WEBHOOK_SECRET_NEW"], ENV["MOLLIE_WEBHOOK_SECRET_OLD"]]
+end
+```
+
+If `webhook_signing_secret` is not configured (`nil`, `""`, or `[]`), all
+events are accepted without verification. A boot-time warning is logged to
+alert operators that verification is disabled.
+
+### Signature verification
+
+The `X-Mollie-Signature` header contains `sha256=<hex_hmac>`. Verification
+uses `request.raw_post` (never re-serialized params) with timing-safe
+comparison via `ActiveSupport::SecurityUtils.secure_compare`.
+
+### Event processing
+
+Events are enqueued as `ProcessWebhookEventJob` with the parsed JSON hash
+(camelCase string keys, as received from Mollie). This is an intentional
+departure from the classic pattern (which passes a single `mollie_id` string)
+because next-gen events include embedded entity data, avoiding an extra API
+fetch. The job routes by event type. Unknown types are logged and accepted
+(200 OK).
+
+## Technical Approach
+
+### Files to create
+
+| File | Purpose |
+|------|---------|
+| `app/controllers/mollie_pay/webhook_events_controller.rb` | Receive + verify next-gen events |
+| `app/jobs/mollie_pay/process_webhook_event_job.rb` | Route events by type |
+| `lib/mollie_pay/webhook_signature.rb` | HMAC verification module |
+| `test/controllers/mollie_pay/webhook_events_controller_test.rb` | Controller tests |
+| `test/jobs/mollie_pay/process_webhook_event_job_test.rb` | Job tests |
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `config/routes.rb` | Add `resources :webhook_events, only: :create` |
+| `lib/mollie_pay/configuration.rb` | Add `webhook_signing_secret` + `webhook_signing_secrets` |
+| `lib/mollie_pay/errors.rb` | Add `InvalidSignature` |
+| `lib/mollie_pay.rb` | Require `webhook_signature` |
+| `lib/mollie_pay/test_helper.rb` | Add `post_signed_webhook_event` helper |
+| `docs/webhooks.md` | Add next-gen section |
+| `AGENTS.md` | Document new endpoint and configuration |
+
+### Implementation details
+
+#### WebhookEventsController
+
+```ruby
+# app/controllers/mollie_pay/webhook_events_controller.rb
+module MolliePay
+  class WebhookEventsController < ApplicationController
+    skip_forgery_protection
+
+    def create
+      raw_body = request.raw_post
+      head :bad_request and return if raw_body.blank?
+
+      verify_signature!(raw_body)
+
+      event = JSON.parse(raw_body)
+
+      if event["id"].present? && event["type"].present?
+        ProcessWebhookEventJob.perform_later(event)
+        head :ok
+      else
+        head :unprocessable_entity
+      end
+    rescue JSON::ParserError
+      head :bad_request
+    rescue MolliePay::InvalidSignature => e
+      Rails.logger.warn("[MolliePay] Webhook signature verification failed: #{e.message}")
+      head :bad_request
+    end
+
+    private
+
+      def verify_signature!(raw_body)
+        secrets = MolliePay.configuration.webhook_signing_secrets
+        return if secrets.nil? # No secret configured — skip verification
+
+        MolliePay::WebhookSignature.verify!(
+          raw_body,
+          request.headers["X-Mollie-Signature"],
+          secrets
+        )
+      end
+  end
+end
+```
+
+**Design notes (from review):**
+- Uses expanded conditional for field validation (not mid-method guard clause,
+  per AGENTS.md convention)
+- Logs `InvalidSignature` at `warn` level before returning 400
+- Returns 400 for all rejection cases (invalid signature, malformed body, empty body)
+- Returns 422 only for valid JSON missing required `id`/`type` fields
+
+#### WebhookSignature module
+
+```ruby
+# lib/mollie_pay/webhook_signature.rb
+require "openssl"
+
+module MolliePay
+  module WebhookSignature
+    module_function
+
+    def verify!(payload, signature_header, secrets)
+      raise MolliePay::InvalidSignature, "Missing signature" if signature_header.blank?
+      raise MolliePay::InvalidSignature, "Invalid signature format" unless signature_header.start_with?("sha256=")
+
+      provided = signature_header.delete_prefix("sha256=")
+
+      verified = Array(secrets).any? do |secret|
+        calculated = OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
+        ActiveSupport::SecurityUtils.secure_compare(calculated, provided)
+      end
+
+      raise MolliePay::InvalidSignature, "Invalid signature" unless verified
+    end
+  end
+end
+```
+
+**Security enhancements (from review):**
+- Explicit `sha256=` prefix validation before HMAC computation
+- `require "openssl"` for explicit dependency declaration
+- `module_function` for stateless utility — never included, only called directly
+
+#### Configuration additions
+
+```ruby
+# lib/mollie_pay/configuration.rb
+attr_accessor :webhook_signing_secret
+
+# Returns nil (not configured) or a non-empty array of secrets.
+# Treats nil, "", and [] as "not configured" — prevents silent rejection
+# when empty array is passed (Array([]).any? would always return false).
+def webhook_signing_secrets
+  secrets = Array(webhook_signing_secret).reject(&:blank?)
+  secrets.empty? ? nil : secrets
+end
+```
+
+#### ProcessWebhookEventJob
+
+```ruby
+# app/jobs/mollie_pay/process_webhook_event_job.rb
+module MolliePay
+  class ProcessWebhookEventJob < ApplicationJob
+    queue_as :default
+
+    retry_on StandardError, wait: :polynomially_longer, attempts: 5
+    # Phase 2: add discard_on for errors that should not retry
+
+    def perform(event)
+      Rails.logger.info("[MolliePay] Received webhook event: #{event['type']} (#{event['entityId']})")
+    end
+  end
+end
+```
+
+**Simplification (from review):** No `case` statement or commented-out branches.
+Just log the event. When Phase 2 (#69) adds handlers, add the `case` routing
+then. The `retry_on` matches the existing `ProcessWebhookJob` pattern and is
+forward-looking for when handlers make API calls.
+
+#### Route
+
+```ruby
+# config/routes.rb
+MolliePay::Engine.routes.draw do
+  resources :webhooks,       only: :create
+  resources :webhook_events, only: :create
+end
+```
+
+#### Test helper
+
+```ruby
+# In lib/mollie_pay/test_helper.rb
+
+WEBHOOK_TEST_SECRET = "test_whsec_000000000000000000000000".freeze
+
+def post_signed_webhook_event(event_type:, entity_id:, secret: WEBHOOK_TEST_SECRET)
+  payload = {
+    resource: "event",
+    id: "whe_test#{SecureRandom.hex(8)}",
+    type: event_type,
+    entityId: entity_id,
+    createdAt: Time.current.iso8601
+  }.to_json
+
+  headers = { "CONTENT_TYPE" => "application/json" }
+  if secret
+    signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', secret, payload)}"
+    headers["HTTP_X_MOLLIE_SIGNATURE"] = signature
+  end
+
+  post mollie_pay.webhook_events_path, params: payload, headers: headers
+end
+```
+
+**Simplification (from review):** Removed `entity`/`_embedded` parameter (YAGNI —
+no handler consumes embedded data in Phase 1). Add when Phase 2 needs it.
+
+**Test setup note:** Tests using this helper must configure the signing secret:
+
+```ruby
+setup do
+  MolliePay.configuration.webhook_signing_secret = MolliePay::TestHelper::WEBHOOK_TEST_SECRET
+end
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Valid signature | 200 OK, enqueue job |
+| Invalid signature | 400 Bad Request, log at warn |
+| Missing `sha256=` prefix | 400 Bad Request (invalid format) |
+| Missing signature + secret configured | 400 Bad Request |
+| Missing signature + no secret | 200 OK, accept |
+| Valid signature + no secret configured | 200 OK, accept (skip verification) |
+| Empty body | 400 Bad Request |
+| Malformed JSON | 400 Bad Request |
+| Missing `id` or `type` fields | 422 Unprocessable Entity |
+| Unknown event type | 200 OK, log at info level |
+| Duplicate event ID | 200 OK, rely on handler idempotency |
+| Secret rotation (array) | Try each secret, any match = valid |
+| `webhook_signing_secret = []` | Treated as "not configured" |
+| `webhook_signing_secret = ""` | Treated as "not configured" |
+
+## Security Considerations
+
+- **`request.raw_post`** for HMAC input — never re-serialize from params
+  (confirmed critical by learnings-researcher: chargeback solution documented
+  this pattern)
+- **`ActiveSupport::SecurityUtils.secure_compare`** — timing-safe, delegates to
+  OpenSSL C-level constant-time comparison
+- **Explicit `sha256=` prefix validation** before HMAC computation — reject
+  malformed headers early
+- **Log invalid signature attempts** at `warn` level with error message (no
+  payload content to avoid data leakage)
+- **Boot-time warning** when no signing secret is configured — operators see
+  that verification is disabled
+- **No replay prevention via timestamp** — Mollie's signature format doesn't
+  include a timestamp (unlike Stripe/Paddle). Accepted risk for Phase 1.
+  Phase 2 handlers MUST be idempotent.
+- `skip_forgery_protection` on the controller (external POST, no CSRF token)
+
+## Acceptance Criteria
+
+- [ ] `webhook_signing_secret` config option (string or array)
+- [ ] `webhook_signing_secrets` method returns nil or non-empty array
+- [ ] `MolliePay::WebhookSignature.verify!` with HMAC-SHA256 verification
+- [ ] Explicit `sha256=` prefix validation in signature module
+- [ ] `MolliePay::InvalidSignature` error class
+- [ ] `POST /mollie_pay/webhook_events` route
+- [ ] `WebhookEventsController` receives events, verifies signature, enqueues job
+- [ ] Returns 200 for valid events, 400 for invalid signature/body, 422 for missing fields
+- [ ] Logs invalid signature attempts at warn level
+- [ ] Accepts all events when no signing secret configured (with boot-time warning)
+- [ ] Secret rotation: accepts if ANY secret in array matches
+- [ ] `ProcessWebhookEventJob` logs received events
+- [ ] Job has `retry_on` and `queue_as :default` matching existing pattern
+- [ ] `post_signed_webhook_event` test helper with configurable secret
+- [ ] Controller tests: valid sig, invalid sig, malformed sig format, missing sig+secret, missing sig+no secret, empty body, malformed JSON, missing fields
+- [ ] Job tests: event logging
+- [ ] `docs/webhooks.md` updated with next-gen section
+- [ ] `AGENTS.md` updated with new endpoint, config, and camelCase key contract
+- [ ] `require "openssl"` in webhook_signature.rb
+
+## Scope Boundaries (explicit non-goals)
+
+- **No OAuth / webhook subscription management** — users create subscriptions
+  via Mollie Dashboard, not via API
+- **No event type handlers** — Phase 2 (#69) adds sales invoice handlers,
+  Phase 3 adds other types. This PR only adds the infrastructure.
+- **No WebhookEvent model** — consistent with AGENTS.md architecture
+- **No Mollie SDK extension** — that's a separate upstream PR
+- **No modification to classic webhooks** — they remain unchanged
+- **No event ID deduplication** — rely on handler idempotency (Phase 2 concern)
+
+## Dependencies & Risks
+
+- **Beta API** — Mollie may change the payload structure, event types, or
+  signature format. Keep the implementation flexible.
+- **No timestamp in signature** — unlike Stripe, Mollie doesn't include a
+  timestamp. Replay attacks are mitigated by handler idempotency.
+- **OAuth-only subscription management** — users must manually set up webhook
+  subscriptions in the Mollie Dashboard until Mollie Connect is added (#55)
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [docs/brainstorms/2026-03-22-next-gen-webhooks-research.md](../../brainstorms/2026-03-22-next-gen-webhooks-research.md)
+  Key decisions carried forward: HMAC verification pattern from PHP SDK,
+  coexistence with classic webhooks, configurable signing secret, no
+  WebhookEvent model
+
+### Institutional Learnings Applied
+
+- **Chargeback solution** (`docs/solutions/integration-issues/mollie-chargeback-model-api-discovery.md`):
+  Use `request.raw_post` for HMAC input, use camelCase in test fixtures matching
+  real API, separate persistence from hook dispatch
+
+### Internal References
+
+- Classic webhook controller: `app/controllers/mollie_pay/webhooks_controller.rb`
+- ProcessWebhookJob pattern: `app/jobs/mollie_pay/process_webhook_job.rb`
+- Configuration: `lib/mollie_pay/configuration.rb`
+- Errors: `lib/mollie_pay/errors.rb`
+- Test helpers: `lib/mollie_pay/test_helper.rb`
+
+### External References
+
+- Mollie Next-Gen Webhooks: https://docs.mollie.com/reference/webhooks-new
+- Mollie Webhooks Best Practices: https://docs.mollie.com/docs/webhooks-best-practices
+- PHP SDK SignatureValidator: https://github.com/mollie/mollie-api-php
+- Stripe webhook.rb (pattern): https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/webhook.rb
+- Pay gem webhook handling: https://github.com/pay-rails/pay
+
+### Related Work
+
+- Next-Gen Webhooks issue: #70
+- Sales Invoices issue: #69
+- Mollie Connect issue: #55

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -95,14 +95,91 @@ Webhook jobs are enqueued on the `:default` queue. Processing includes:
 - **Discard policy:** Mollie 404s and locally unknown subscription/refund IDs are discarded immediately
 - **Idempotency:** `record_from_mollie` uses `find_or_initialize_by` — safe to process the same webhook multiple times
 
+## Next-Gen Webhooks (beta)
+
+MolliePay also supports Mollie's **Next-Gen Webhooks** — event-based webhook
+subscriptions with HMAC-SHA256 signature verification. These are separate from
+classic webhooks and provide event types not available via the classic approach
+(e.g., `sales-invoice.paid`).
+
+### Endpoint
+
+```
+POST https://yourapp.com/mollie_pay/webhook_events
+```
+
+Register this URL in the Mollie Dashboard under Webhooks. Select the event
+types you want to receive.
+
+### Configuration
+
+```ruby
+MolliePay.configure do |config|
+  config.webhook_signing_secret = ENV["MOLLIE_WEBHOOK_SIGNING_SECRET"]
+end
+```
+
+The signing secret is displayed once when you create the webhook subscription
+in the Mollie Dashboard. Store it immediately — it cannot be retrieved later.
+
+If `webhook_signing_secret` is not configured, events are accepted without
+signature verification. **This is not recommended for production.**
+
+For secret rotation, pass an array:
+
+```ruby
+config.webhook_signing_secret = [
+  ENV["MOLLIE_WEBHOOK_SECRET_NEW"],
+  ENV["MOLLIE_WEBHOOK_SECRET_OLD"]
+]
+```
+
+### How it works
+
+```
+POST /mollie_pay/webhook_events     (from Mollie, with X-Mollie-Signature header)
+  → verify HMAC-SHA256 signature    (if signing secret configured)
+  → parse JSON event payload
+  → validate required fields (id, type)
+  → ProcessWebhookEventJob.perform_later(event)
+  → head :ok
+```
+
+### Event payload
+
+```json
+{
+  "resource": "event",
+  "id": "whe_xxx",
+  "type": "sales-invoice.paid",
+  "entityId": "invoice_xxx",
+  "createdAt": "2026-03-22T10:00:00+00:00",
+  "_embedded": {
+    "entity": { ... }
+  }
+}
+```
+
+### Classic vs Next-Gen coexistence
+
+Both endpoints are active simultaneously:
+
+| Endpoint | Payload | Verification | Events |
+|----------|---------|-------------|--------|
+| `POST /mollie_pay/webhooks` | Resource ID only | API key (implicit) | Payment, subscription, refund status changes |
+| `POST /mollie_pay/webhook_events` | Full event JSON | HMAC signature | Sales invoices, payment links, future types |
+
+Classic webhooks are **not** deprecated. Payment and subscription status changes
+are currently only available via classic webhooks.
+
 ## Rate limiting
 
-The webhook endpoint is publicly accessible by design. Consider rate limiting
-it at the infrastructure level:
+Both webhook endpoints are publicly accessible by design. Consider rate
+limiting them at the infrastructure level:
 
 ```ruby
 # config/initializers/rack_attack.rb
 Rack::Attack.throttle("mollie_webhooks", limit: 100, period: 60) do |req|
-  req.path == "/mollie_pay/webhooks" && req.post? && req.ip
+  (req.path == "/mollie_pay/webhooks" || req.path == "/mollie_pay/webhook_events") && req.post? && req.ip
 end
 ```

--- a/lib/mollie_pay.rb
+++ b/lib/mollie_pay.rb
@@ -2,6 +2,7 @@ require "mollie-api-ruby"
 require "mollie_pay/version"
 require "mollie_pay/errors"
 require "mollie_pay/configuration"
+require "mollie_pay/webhook_signature"
 require "mollie_pay/engine"
 
 module MolliePay

--- a/lib/mollie_pay/configuration.rb
+++ b/lib/mollie_pay/configuration.rb
@@ -6,6 +6,7 @@ module MolliePay
     attr_accessor :host
     attr_accessor :default_redirect_path
     attr_accessor :currency
+    attr_accessor :webhook_signing_secret
 
     def initialize
       @currency = "EUR"
@@ -25,6 +26,14 @@ module MolliePay
 
       path = default_redirect_path.gsub(":id", payment.id.to_s)
       "#{host_without_trailing_slash}#{path}"
+    end
+
+    # Returns nil (not configured) or a non-empty array of secrets.
+    # Treats nil, "", and [] as "not configured" to prevent silent rejection
+    # when an empty array is passed.
+    def webhook_signing_secrets
+      secrets = Array(webhook_signing_secret).reject(&:blank?)
+      secrets.empty? ? nil : secrets
     end
 
     def inspect

--- a/lib/mollie_pay/engine.rb
+++ b/lib/mollie_pay/engine.rb
@@ -9,5 +9,16 @@ module MolliePay
         end
       end
     end
+
+    initializer "mollie_pay.warn_missing_webhook_secret", after: :finisher_hook do
+      config.after_initialize do
+        if MolliePay.configuration.webhook_signing_secrets.nil?
+          Rails.logger.warn(
+            "[MolliePay] webhook_signing_secret is not configured. " \
+            "Next-gen webhook events at /webhook_events will be accepted without signature verification."
+          )
+        end
+      end
+    end
   end
 end

--- a/lib/mollie_pay/errors.rb
+++ b/lib/mollie_pay/errors.rb
@@ -3,4 +3,5 @@ module MolliePay
   class MandateRequired      < Error; end
   class SubscriptionNotFound < Error; end
   class PaymentNotCancelable < Error; end
+  class InvalidSignature     < Error; end
 end

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -110,6 +110,38 @@ module MolliePay
       Mollie::Refund.stub(:create, response, &block)
     end
 
+    # ── Next-Gen Webhook Event helpers ──────────────────────────────
+    #
+    # Post a signed next-gen webhook event to the engine's webhook_events
+    # endpoint. Generates a valid HMAC-SHA256 signature using the provided
+    # secret (or the test default).
+    #
+    #   MolliePay.configuration.webhook_signing_secret = WEBHOOK_TEST_SECRET
+    #   post_signed_webhook_event(event_type: "sales-invoice.paid", entity_id: "invoice_xxx")
+    #   assert_response :ok
+    #
+    # Pass `secret: nil` to omit the signature header (for testing unsigned events).
+    #
+    WEBHOOK_TEST_SECRET = "test_whsec_000000000000000000000000".freeze
+
+    def post_signed_webhook_event(event_type:, entity_id:, secret: WEBHOOK_TEST_SECRET)
+      payload = {
+        resource: "event",
+        id: "whe_test#{SecureRandom.hex(8)}",
+        type: event_type,
+        entityId: entity_id,
+        createdAt: Time.current.iso8601
+      }.to_json
+
+      headers = { "CONTENT_TYPE" => "application/json" }
+      if secret
+        signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', secret, payload)}"
+        headers["HTTP_X_MOLLIE_SIGNATURE"] = signature
+      end
+
+      post mollie_pay.webhook_events_path, params: payload, headers: headers
+    end
+
     # Build a fake Mollie payment response (OpenStruct).
     def fake_mollie_payment(id: nil, status: "open", checkout_url: nil)
       id           ||= "tr_test#{SecureRandom.hex(4)}"

--- a/lib/mollie_pay/webhook_signature.rb
+++ b/lib/mollie_pay/webhook_signature.rb
@@ -1,0 +1,21 @@
+require "openssl"
+
+module MolliePay
+  module WebhookSignature
+    module_function
+
+    def verify!(payload, signature_header, secrets)
+      raise MolliePay::InvalidSignature, "Missing signature" if signature_header.blank?
+      raise MolliePay::InvalidSignature, "Invalid signature format" unless signature_header.start_with?("sha256=")
+
+      provided = signature_header.delete_prefix("sha256=")
+
+      verified = Array(secrets).any? do |secret|
+        calculated = OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
+        ActiveSupport::SecurityUtils.secure_compare(calculated, provided)
+      end
+
+      raise MolliePay::InvalidSignature, "Invalid signature" unless verified
+    end
+  end
+end

--- a/test/controllers/mollie_pay/webhook_events_controller_test.rb
+++ b/test/controllers/mollie_pay/webhook_events_controller_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+module MolliePay
+  class WebhookEventsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      MolliePay.configuration.webhook_signing_secret = WEBHOOK_TEST_SECRET
+    end
+
+    teardown do
+      MolliePay.configuration.webhook_signing_secret = nil
+    end
+
+    test "accepts validly signed event and enqueues job" do
+      assert_enqueued_with(job: ProcessWebhookEventJob) do
+        post_signed_webhook_event(event_type: "sales-invoice.paid", entity_id: "invoice_test123")
+      end
+
+      assert_response :ok
+    end
+
+    test "rejects invalid signature" do
+      payload = { resource: "event", id: "whe_test1", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+      signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+
+      assert_response :bad_request
+    end
+
+    test "rejects malformed signature format" do
+      payload = { resource: "event", id: "whe_test1", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => "md5=abc123" }
+
+      assert_response :bad_request
+    end
+
+    test "rejects missing signature when secret is configured" do
+      payload = { resource: "event", id: "whe_test1", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json" }
+
+      assert_response :bad_request
+    end
+
+    test "accepts event without signature when no secret configured" do
+      MolliePay.configuration.webhook_signing_secret = nil
+
+      payload = { resource: "event", id: "whe_test1", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+
+      assert_enqueued_with(job: ProcessWebhookEventJob) do
+        post mollie_pay.webhook_events_path,
+          params: payload,
+          headers: { "CONTENT_TYPE" => "application/json" }
+      end
+
+      assert_response :ok
+    end
+
+    test "accepts event with valid signature when no secret configured" do
+      MolliePay.configuration.webhook_signing_secret = nil
+
+      post_signed_webhook_event(event_type: "sales-invoice.paid", entity_id: "invoice_1")
+
+      assert_response :ok
+    end
+
+    test "rejects empty body" do
+      post mollie_pay.webhook_events_path,
+        params: "",
+        headers: { "CONTENT_TYPE" => "application/json" }
+
+      assert_response :bad_request
+    end
+
+    test "rejects malformed JSON" do
+      raw = "not json at all"
+      signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', WEBHOOK_TEST_SECRET, raw)}"
+
+      post mollie_pay.webhook_events_path,
+        params: raw,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+
+      assert_response :bad_request
+    end
+
+    test "rejects JSON missing required id field" do
+      payload = { resource: "event", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+      signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', WEBHOOK_TEST_SECRET, payload)}"
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "rejects JSON missing required type field" do
+      payload = { resource: "event", id: "whe_test1", entityId: "invoice_1" }.to_json
+      signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', WEBHOOK_TEST_SECRET, payload)}"
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "accepts unknown event types" do
+      assert_enqueued_with(job: ProcessWebhookEventJob) do
+        post_signed_webhook_event(event_type: "future.unknown-event", entity_id: "entity_1")
+      end
+
+      assert_response :ok
+    end
+
+    test "secret rotation: accepts when second secret matches" do
+      MolliePay.configuration.webhook_signing_secret = [ "new_secret_abc", "old_secret_xyz" ]
+
+      payload = { resource: "event", id: "whe_rot1", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+      signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', 'old_secret_xyz', payload)}"
+
+      assert_enqueued_with(job: ProcessWebhookEventJob) do
+        post mollie_pay.webhook_events_path,
+          params: payload,
+          headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+      end
+
+      assert_response :ok
+    end
+
+    test "secret rotation: rejects when no secret matches" do
+      MolliePay.configuration.webhook_signing_secret = [ "secret_a", "secret_b" ]
+
+      payload = { resource: "event", id: "whe_rot2", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+      signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', 'secret_c_wrong', payload)}"
+
+      post mollie_pay.webhook_events_path,
+        params: payload,
+        headers: { "CONTENT_TYPE" => "application/json", "HTTP_X_MOLLIE_SIGNATURE" => signature }
+
+      assert_response :bad_request
+    end
+
+    test "empty array signing secret is treated as not configured" do
+      MolliePay.configuration.webhook_signing_secret = []
+
+      payload = { resource: "event", id: "whe_empty", type: "sales-invoice.paid", entityId: "invoice_1" }.to_json
+
+      assert_enqueued_with(job: ProcessWebhookEventJob) do
+        post mollie_pay.webhook_events_path,
+          params: payload,
+          headers: { "CONTENT_TYPE" => "application/json" }
+      end
+
+      assert_response :ok
+    end
+  end
+end

--- a/test/jobs/mollie_pay/process_webhook_event_job_test.rb
+++ b/test/jobs/mollie_pay/process_webhook_event_job_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+module MolliePay
+  class ProcessWebhookEventJobTest < ActiveJob::TestCase
+    test "logs received event type and entity ID" do
+      event = {
+        "resource" => "event",
+        "id" => "whe_test123",
+        "type" => "sales-invoice.paid",
+        "entityId" => "invoice_abc",
+        "createdAt" => "2026-03-22T10:00:00+00:00"
+      }
+
+      assert_nothing_raised do
+        ProcessWebhookEventJob.perform_now(event)
+      end
+    end
+
+    test "handles unknown event types without raising" do
+      event = {
+        "resource" => "event",
+        "id" => "whe_unknown",
+        "type" => "future.unknown-type",
+        "entityId" => "entity_xyz"
+      }
+
+      assert_nothing_raised do
+        ProcessWebhookEventJob.perform_now(event)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `POST /mollie_pay/webhook_events` endpoint for Mollie's Next-Gen Webhooks (beta)
- HMAC-SHA256 signature verification via `MolliePay::WebhookSignature` module
- `webhook_signing_secret` configuration option (string or array for secret rotation)
- `ProcessWebhookEventJob` for async event processing (logs events in Phase 1)
- `post_signed_webhook_event` test helper for easy integration testing
- Coexists with classic webhooks — both endpoints active simultaneously

## Key Design Decisions
- **Separate endpoint** — `/webhook_events` alongside `/webhooks`, not replacing it. Classic and next-gen have fundamentally different payloads and verification mechanisms
- **HMAC verification is optional** — if `webhook_signing_secret` is not configured, events are accepted without verification (for Dashboard-only setups). Not recommended for production
- **`sha256=` prefix validated explicitly** — malformed signature formats are rejected before HMAC computation
- **Multi-secret support** — array of secrets for zero-downtime rotation (Mollie provides 24hr grace period)
- **camelCase keys preserved** — job receives Mollie's original JSON keys, no snake_case conversion
- **Phase 1 = infrastructure only** — no event handlers yet. Phase 2 (#69) adds sales invoice handlers

## Security
- `request.raw_post` for HMAC input (never re-serialized params)
- `ActiveSupport::SecurityUtils.secure_compare` for timing-safe comparison
- Invalid signature attempts logged at `warn` level
- Empty body, malformed JSON, missing fields all rejected before job enqueue

## Testing
- 14 controller tests: valid/invalid/malformed signatures, missing signatures ± secret, empty body, malformed JSON, missing fields, unknown event types, secret rotation (accept 2nd secret), rotation reject, empty array normalization
- 2 job tests: event logging, unknown event types
- All 195 tests pass, 0 rubocop offenses

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: library gem, no deployed service. Host apps should monitor webhook signature verification failures via `[MolliePay] Webhook signature verification failed` log messages.

Closes #70