### PR TITLE
feat: Sales Invoices API support (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,44 @@ MolliePay.payment_methods(amount: 1000)          # filtered by amount (cents)
 MolliePay.payment_method("ideal")                # single method details
 ```
 
+### Sales Invoices (beta)
+
+Create, retrieve, and manage sales invoices through Mollie's Sales Invoices API.
+No local model is stored — all data lives on Mollie's side.
+
+```ruby
+# Create a draft invoice
+invoice = current_organization.mollie_create_sales_invoice(
+  lines: [{ description: "Pro plan", quantity: 1, vat_rate: "21.00", unit_price: 8900 }]
+)
+
+# Create and send immediately
+invoice = current_organization.mollie_create_sales_invoice(
+  status: "issued",
+  lines: [{ description: "Pro plan", quantity: 1, vat_rate: "21.00", unit_price: 8900 }],
+  email_details: { subject: "Your invoice", body: "Please pay within 30 days" }
+)
+
+# With explicit recipient (overrides auto-populated fields)
+invoice = MolliePay.create_sales_invoice(
+  status: "draft",
+  recipient: { type: "business", organization_name: "Acme B.V.", email: "billing@acme.nl" },
+  lines: [{ description: "Consulting", quantity: 10, vat_rate: "21.00", unit_price: 15000 }],
+  payment_term: "30 days",
+  memo: "Thank you for your business!"
+)
+
+# Retrieve, list, update, delete
+invoice = MolliePay.sales_invoice("invoice_abc123")
+invoices = MolliePay.sales_invoices
+MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated memo")
+MolliePay.delete_sales_invoice("invoice_abc123")  # draft only
+```
+
+Line item `unit_price` accepts cents (integer) and is converted automatically.
+The Billable convenience method auto-populates the recipient from your model's
+`name` and `email` attributes.
+
 ### Query state
 
 ```ruby

--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -177,6 +177,21 @@ module MolliePay
       MolliePay.payment_methods(**options)
     end
 
+    # === Sales Invoices (beta) ===
+
+    def mollie_create_sales_invoice(lines:, status: "draft", recipient: nil, **options)
+      resolved_recipient = recipient || build_sales_invoice_recipient
+      MolliePay.create_sales_invoice(status: status, recipient: resolved_recipient, lines: lines, **options)
+    end
+
+    def mollie_sales_invoices(**options)
+      MolliePay.sales_invoices(**options)
+    end
+
+    def mollie_sales_invoice(id)
+      MolliePay.sales_invoice(id)
+    end
+
     # === Hooks — override these in your model ===
 
     def on_mollie_payment_paid(payment)             ; end
@@ -244,6 +259,21 @@ module MolliePay
         idempotency_key: SecureRandom.uuid
       )
       create_mollie_customer!(mollie_id: mc.id)
+    end
+
+    def build_sales_invoice_recipient
+      if respond_to?(:organization_name) && organization_name.present?
+        { type: "business", organization_name: organization_name }.tap do |r|
+          r[:email]      = email      if respond_to?(:email) && email.present?
+          r[:vat_number] = vat_number if respond_to?(:vat_number) && vat_number.present?
+        end
+      else
+        {}.tap do |r|
+          r[:type]        = "consumer"
+          r[:given_name]  = name       if respond_to?(:name) && name.present?
+          r[:email]       = email      if respond_to?(:email) && email.present?
+        end
+      end
     end
 
     def mollie_amount(cents)

--- a/docs/plans/2026-03-26-001-feat-sales-invoices-api-support-plan.md
+++ b/docs/plans/2026-03-26-001-feat-sales-invoices-api-support-plan.md
@@ -1,0 +1,245 @@
+---
+title: "feat: Add Sales Invoices API support (beta)"
+type: feat
+status: completed
+date: 2026-03-26
+---
+
+# feat: Add Sales Invoices API support (beta)
+
+## Overview
+
+Add support for Mollie's Sales Invoices API (beta), enabling host apps to create, retrieve, update, delete, and list sales invoices through the MolliePay gem. This follows the class-method-only pattern (like `payment_methods`) — no local ActiveRecord model, since there's no per-resource webhook support for sales invoices via API keys.
+
+## Problem Frame
+
+Mollie's Sales Invoices API lets merchants create and send invoices to their customers. The `mollie-api-ruby` SDK does not have a `SalesInvoice` class, and the existing `Mollie::Invoice` represents Mollie's fee invoices to the merchant — a completely different resource. Host apps currently have no way to use this API through mollie_pay.
+
+Related: GitHub issue #69
+
+## Requirements Trace
+
+- R1. Provide a `Mollie::SalesInvoice` SDK extension class that maps to the `/v2/sales-invoices` endpoint
+- R2. Expose CRUD + list operations as class methods on the `MolliePay` module
+- R3. Add Billable convenience methods that auto-populate recipient from the billable model
+- R4. Handle amount conversion (cents → Mollie format) consistently with existing patterns
+- R5. Handle nested hash key camelization for recipient, emailDetails, paymentDetails
+- R6. Mark the feature as beta/experimental in documentation
+- R7. Follow existing test patterns (Minitest, stub-based, no real HTTP)
+
+## Scope Boundaries
+
+- No local ActiveRecord model or migration — the issue recommends deferring this until webhook support is available via API keys
+- No webhook/event processing for sales invoices — `ProcessWebhookEventJob` remains a logger for now
+- No PDF download helper — the PDF URL is available in the response `_links`
+- No polling/background sync — host apps check status on demand
+- No OAuth/Mollie Connect integration (that's issue #55)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/mollie_pay.rb` — class-method-only pattern (`payment_methods`, `payment_method`)
+- `app/models/mollie_pay/billable.rb` — convenience delegation (`mollie_payment_methods`)
+- `test/lib/mollie_pay/payment_methods_test.rb` — test pattern for class-method features
+- `mollie-api-ruby` `Mollie::Base` — SDK base class with CRUD, derives API path from class name
+- `mollie-api-ruby` `Mollie::Client#perform_http_call` — camelizes top-level keys, but only recurses into `CAMELIZE_NESTED` keys (includes `lines` but not `recipient`, `email_details`, etc.)
+- `lib/mollie_pay/errors.rb` — custom error classes
+
+### Institutional Learnings
+
+- From `docs/solutions/integration-issues/mollie-chargeback-model-api-discovery.md`: Always verify API responses against live data, use camelCase in test fixtures, check `attributes` hash for fields not exposed via `attr_accessor`
+
+## Key Technical Decisions
+
+- **SDK extension in mollie_pay, not upstream PR**: Create `Mollie::SalesInvoice` within the gem's `lib/` directory. The SDK doesn't have this class and an upstream PR is a separate effort. This keeps us unblocked. The class inherits from `Mollie::Base` and overrides `resource_name` to return `"sales-invoices"` (hyphenated, matching the API endpoint).
+
+- **Deep camelization for nested hashes**: The SDK's `camelize_keys` only recurses into keys listed in `CAMELIZE_NESTED` (includes `lines` but not `recipient`, `email_details`, `payment_details`). The `MolliePay` module methods will accept Ruby-idiomatic snake_case hashes and convert nested objects to camelCase before passing to the SDK. This keeps the public API clean.
+
+- **Class methods on MolliePay module**: Following the `payment_methods` pattern exactly — `MolliePay.create_sales_invoice(...)`, `MolliePay.sales_invoice(id)`, `MolliePay.sales_invoices`, `MolliePay.update_sales_invoice(id, ...)`, `MolliePay.delete_sales_invoice(id)`.
+
+- **Billable convenience**: `mollie_create_sales_invoice(...)` that auto-populates recipient fields from the billable model, and `mollie_sales_invoices` / `mollie_sales_invoice(id)` that delegate to `MolliePay`.
+
+- **Amount handling**: Accept cents integers in the public API, convert to Mollie format at the API boundary using the same `format("%.2f", cents / 100.0)` pattern. Line item `unit_price` follows the same conversion.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does the SDK extension live?** In `lib/mollie/sales_invoice.rb`, loaded by `lib/mollie_pay.rb`. This mirrors how a gem would extend another gem's namespace — clean and conventional.
+- **How to handle the hyphenated API path?** Override `self.resource_name` on `Mollie::SalesInvoice` to return `"sales-invoices"` since the SDK's default derivation would produce `"salesinvoices"`.
+
+### Deferred to Implementation
+
+- **Exact attr_accessor list**: The issue documents the response fields, but the final list should be verified against the actual API response structure during implementation.
+- **Whether `Util.camelize_keys` handles `lines` correctly for sales invoice line items**: The `lines` key IS in `CAMELIZE_NESTED`, so inner keys like `vat_rate` should be camelized. Verify during testing.
+
+## Implementation Units
+
+- [ ] **Unit 1: Mollie::SalesInvoice SDK extension class**
+
+  **Goal:** Create a `Mollie::SalesInvoice` class that extends `Mollie::Base` and maps to the `/v2/sales-invoices` endpoint, providing CRUD + list operations via the SDK's standard patterns.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `lib/mollie/sales_invoice.rb`
+  - Modify: `lib/mollie_pay.rb` (add require)
+  - Test: `test/lib/mollie/sales_invoice_test.rb`
+
+  **Approach:**
+  - Inherit from `Mollie::Base`
+  - Override `self.resource_name` to return `"sales-invoices"`
+  - Add `attr_accessor` for all documented response fields (snake_case, as the SDK auto-converts)
+  - Add status constants: `STATUS_DRAFT`, `STATUS_ISSUED`, `STATUS_PAID`, `STATUS_CANCELED`
+  - Add status predicates: `draft?`, `issued?`, `paid?`, `canceled?`
+  - Add link helpers: `pdf_url`, `payment_url` (extract from `_links` using `Mollie::Util.extract_url`)
+  - Amount fields (`subtotal_amount`, `total_vat_amount`, `total_amount`, `amount_due`) should have setters that convert hashes to `Mollie::Amount` if present
+
+  **Patterns to follow:**
+  - `Mollie::Payment` in the SDK for attr_accessor structure and amount handling
+  - `Mollie::Base` for CRUD pattern
+
+  **Test scenarios:**
+  - `resource_name` returns `"sales-invoices"`
+  - Initializing from a response hash populates all attributes
+  - Status predicates return correct booleans
+  - `pdf_url` and `payment_url` extract correctly from `_links`
+  - Class methods (`create`, `get`, `all`, `update`, `delete`) are inherited from Base and callable
+
+  **Verification:**
+  - `Mollie::SalesInvoice.resource_name` returns `"sales-invoices"`
+  - A `Mollie::SalesInvoice` instance initializes cleanly from a camelCase API response hash
+
+- [ ] **Unit 2: MolliePay module class methods for Sales Invoices**
+
+  **Goal:** Add public class methods on the `MolliePay` module for all sales invoice operations, handling amount conversion and nested hash camelization.
+
+  **Requirements:** R2, R4, R5
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `lib/mollie_pay.rb`
+  - Test: `test/lib/mollie_pay/sales_invoices_test.rb`
+
+  **Approach:**
+  - `MolliePay.create_sales_invoice(status:, recipient:, lines:, **options)` — converts line item amounts from cents, camelizes nested hashes, calls `Mollie::SalesInvoice.create`
+  - `MolliePay.sales_invoice(id)` — calls `Mollie::SalesInvoice.get(id)`
+  - `MolliePay.sales_invoices(**options)` — calls `Mollie::SalesInvoice.all(options)`
+  - `MolliePay.update_sales_invoice(id, **attrs)` — calls `Mollie::SalesInvoice.update(id, attrs)`
+  - `MolliePay.delete_sales_invoice(id)` — calls `Mollie::SalesInvoice.delete(id)`
+  - Add a private `deep_camelize_keys` helper on the module for converting nested snake_case hashes to camelCase (needed because the SDK only camelizes top-level keys for non-CAMELIZE_NESTED keys)
+  - Line item `unit_price` accepts cents integer and converts to Mollie amount format
+  - `email_details` and `payment_details` hashes are deep-camelized
+
+  **Patterns to follow:**
+  - `MolliePay.payment_methods` / `MolliePay.payment_method` for structure
+  - `mollie_amount` helper pattern for amount conversion
+
+  **Test scenarios:**
+  - `create_sales_invoice` passes correct camelCase params to SDK
+  - Line item `unit_price` in cents is converted to Mollie amount format
+  - `recipient` hash keys are camelized (e.g., `given_name` → `givenName`)
+  - `email_details` hash keys are camelized (e.g., `subject` stays, but `email_details` → `emailDetails`)
+  - `sales_invoice(id)` delegates to `Mollie::SalesInvoice.get`
+  - `sales_invoices` delegates to `Mollie::SalesInvoice.all`
+  - `update_sales_invoice` delegates to `Mollie::SalesInvoice.update`
+  - `delete_sales_invoice` delegates to `Mollie::SalesInvoice.delete`
+  - Options like `payment_term`, `vat_scheme`, `vat_mode`, `memo`, `metadata` are forwarded
+
+  **Verification:**
+  - All five methods exist and delegate correctly
+  - Amount conversion matches existing pattern (cents → `{ currency: "EUR", value: "10.00" }`)
+  - Nested hashes arrive at the SDK with correct camelCase keys
+
+- [ ] **Unit 3: Billable concern convenience methods**
+
+  **Goal:** Add convenience methods to the Billable concern that auto-populate recipient data from the billable model and delegate to `MolliePay` module methods.
+
+  **Requirements:** R3, R4
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `app/models/mollie_pay/billable.rb`
+  - Modify: `test/models/mollie_pay/billable_test.rb`
+
+  **Approach:**
+  - `mollie_create_sales_invoice(lines:, status: "draft", **options)` — builds recipient hash from billable model attributes (name, email, and address if available), merges with any explicit `recipient:` override, delegates to `MolliePay.create_sales_invoice`
+  - `mollie_sales_invoices(**options)` — delegates to `MolliePay.sales_invoices`
+  - `mollie_sales_invoice(id)` — delegates to `MolliePay.sales_invoice(id)`
+  - Recipient auto-population: check `respond_to?` for `:name`, `:email`, `:organization_name` etc., building a consumer or business recipient hash based on available attributes. The explicit `recipient:` parameter always wins.
+
+  **Patterns to follow:**
+  - `mollie_payment_methods(**options)` delegation pattern
+  - `create_mollie_customer_on_mollie` for `respond_to?` checks on billable model
+
+  **Test scenarios:**
+  - `mollie_create_sales_invoice` auto-populates recipient from billable model
+  - Explicit `recipient:` overrides auto-populated values
+  - `mollie_sales_invoices` delegates correctly
+  - `mollie_sales_invoice(id)` delegates correctly
+  - Line items with `unit_price` in cents are passed through correctly
+
+  **Verification:**
+  - Billable convenience methods exist and delegate to `MolliePay` module
+  - Recipient auto-population works for models with name/email attributes
+
+- [ ] **Unit 4: Test helper stubs and documentation**
+
+  **Goal:** Add test helper methods for sales invoices following the existing stub pattern, and add usage examples to the README.
+
+  **Requirements:** R6, R7
+
+  **Dependencies:** Units 1-3
+
+  **Files:**
+  - Modify: `lib/mollie_pay/test_helper.rb`
+  - Create: `lib/mollie_pay/test_fixtures/sales_invoice.json`
+  - Modify: `README.md` (sales invoices section)
+
+  **Approach:**
+  - Add `fake_mollie_sales_invoice` helper returning an OpenStruct with standard fields
+  - Add `stub_mollie_sales_invoice_create` and `stub_mollie_sales_invoice_get` helpers
+  - Add WebMock helpers: `webmock_mollie_sales_invoice_create`, `webmock_mollie_sales_invoice_get`
+  - Create `sales_invoice.json` fixture with camelCase keys matching the real API response
+  - Add a "Sales Invoices (beta)" section to README with create, get, list, update, delete examples
+  - Mark the section as beta/experimental
+
+  **Patterns to follow:**
+  - Existing test helpers in `lib/mollie_pay/test_helper.rb`
+  - Existing JSON fixtures in `lib/mollie_pay/test_fixtures/`
+  - README structure for existing features
+
+  **Test scenarios:**
+  - Test helpers produce valid fake objects
+  - JSON fixture has camelCase keys and includes all documented response fields
+
+  **Verification:**
+  - All existing tests still pass
+  - New test helpers are usable in a test context
+  - README documents the beta feature with clear examples
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks, middleware, or observers affected. The feature is additive — new class methods on `MolliePay` and new methods on `Billable`. No existing behavior changes.
+- **Error propagation:** SDK errors (`Mollie::RequestError`, `Mollie::ResourceNotFoundError`) propagate naturally from `Mollie::SalesInvoice` through the `MolliePay` module methods to the caller. No custom error wrapping needed.
+- **State lifecycle risks:** None — no local model, no state to manage. All state lives on Mollie's side.
+- **API surface parity:** The `ProcessWebhookEventJob` currently logs all events. When sales invoice events arrive via next-gen webhooks, they will be logged but not processed. This is acceptable for now and documented as a future enhancement.
+- **Integration coverage:** Unit tests with stubs are sufficient since there's no local state. The SDK extension class is tested for correct API path generation and attribute mapping.
+
+## Risks & Dependencies
+
+- **Beta API instability:** The Sales Invoices API is in beta. Fields, behavior, or endpoints may change. The feature should be clearly marked as beta.
+- **SDK key camelization gap:** The `camelize_keys` method in the SDK doesn't recurse into `recipient` or `email_details` keys. The `deep_camelize_keys` helper in `MolliePay` handles this, but if the SDK adds `SalesInvoice` support natively in the future, we should migrate to it and remove our extension.
+- **No webhook-driven sync:** Without webhooks, invoice payment status must be checked on demand. Host apps need to poll or check manually. This is an intentional scope boundary.
+
+## Sources & References
+
+- Related issue: #69
+- Mollie Sales Invoices API: https://docs.mollie.com/reference/create-sales-invoice
+- Mollie Connect / OAuth: #55 (future dependency for webhook support)
+- `mollie-api-ruby` SDK: https://github.com/mollie/mollie-api-ruby

--- a/lib/mollie/sales_invoice.rb
+++ b/lib/mollie/sales_invoice.rb
@@ -1,0 +1,124 @@
+module Mollie
+  class SalesInvoice < Base
+    STATUS_DRAFT    = "draft".freeze
+    STATUS_ISSUED   = "issued".freeze
+    STATUS_PAID     = "paid".freeze
+    STATUS_CANCELED = "canceled".freeze
+
+    attr_accessor :id,
+                  :profile_id,
+                  :status,
+                  :invoice_number,
+                  :recipient_identifier,
+                  :recipient,
+                  :lines,
+                  :payment_term,
+                  :vat_scheme,
+                  :vat_mode,
+                  :memo,
+                  :metadata,
+                  :is_e_invoice,
+                  :email_details,
+                  :payment_details,
+                  :subtotal_amount,
+                  :discounted_subtotal_amount,
+                  :total_vat_amount,
+                  :total_amount,
+                  :amount_due,
+                  :created_at,
+                  :issued_at,
+                  :paid_at,
+                  :due_at,
+                  :_links
+
+    alias links _links
+
+    def self.resource_name(_parent_id = nil)
+      "sales-invoices"
+    end
+
+    def draft?
+      status == STATUS_DRAFT
+    end
+
+    def issued?
+      status == STATUS_ISSUED
+    end
+
+    def paid?
+      status == STATUS_PAID
+    end
+
+    def canceled?
+      status == STATUS_CANCELED
+    end
+
+    def pdf_url
+      Util.extract_url(links, "pdf_link")
+    end
+
+    def payment_url
+      Util.extract_url(links, "invoice_payment")
+    end
+
+    def subtotal_amount=(amount)
+      @subtotal_amount = Amount.new(amount) if amount
+    end
+
+    def discounted_subtotal_amount=(amount)
+      @discounted_subtotal_amount = Amount.new(amount) if amount
+    end
+
+    def total_vat_amount=(amount)
+      @total_vat_amount = Amount.new(amount) if amount
+    end
+
+    def total_amount=(amount)
+      @total_amount = Amount.new(amount) if amount
+    end
+
+    def amount_due=(amount)
+      @amount_due = Amount.new(amount) if amount
+    end
+
+    def created_at=(value)
+      @created_at = begin
+                      Time.parse(value.to_s)
+                    rescue StandardError
+                      nil
+                    end
+    end
+
+    def issued_at=(value)
+      @issued_at = begin
+                     Time.parse(value.to_s)
+                   rescue StandardError
+                     nil
+                   end
+    end
+
+    def paid_at=(value)
+      @paid_at = begin
+                   Time.parse(value.to_s)
+                 rescue StandardError
+                   nil
+                 end
+    end
+
+    def due_at=(value)
+      @due_at = begin
+                  Time.parse(value.to_s)
+                rescue StandardError
+                  nil
+                end
+    end
+
+    def recipient=(recipient)
+      @recipient = OpenStruct.new(recipient) if recipient.is_a?(Hash)
+    end
+
+    def metadata=(metadata)
+      @metadata = OpenStruct.new(metadata) if metadata.is_a?(Hash)
+    end
+  end
+end

--- a/lib/mollie/sales_invoice.rb
+++ b/lib/mollie/sales_invoice.rb
@@ -84,7 +84,7 @@ module Mollie
     def created_at=(value)
       @created_at = begin
                       Time.parse(value.to_s)
-                    rescue StandardError
+                    rescue ArgumentError
                       nil
                     end
     end
@@ -92,7 +92,7 @@ module Mollie
     def issued_at=(value)
       @issued_at = begin
                      Time.parse(value.to_s)
-                   rescue StandardError
+                   rescue ArgumentError
                      nil
                    end
     end
@@ -100,7 +100,7 @@ module Mollie
     def paid_at=(value)
       @paid_at = begin
                    Time.parse(value.to_s)
-                 rescue StandardError
+                 rescue ArgumentError
                    nil
                  end
     end
@@ -108,7 +108,7 @@ module Mollie
     def due_at=(value)
       @due_at = begin
                   Time.parse(value.to_s)
-                rescue StandardError
+                rescue ArgumentError
                   nil
                 end
     end

--- a/lib/mollie_pay.rb
+++ b/lib/mollie_pay.rb
@@ -76,7 +76,7 @@ module MolliePay
   #   MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated memo")
   #
   def self.update_sales_invoice(id, **attrs)
-    params = deep_camelize_keys(attrs)
+    params = deep_camelize_keys(attrs.except(:recipient, :lines))
     params[:recipient] = deep_camelize_keys(attrs[:recipient]) if attrs[:recipient]
     params[:lines] = attrs[:lines].map { |line| build_sales_invoice_line(line) } if attrs[:lines]
     Mollie::SalesInvoice.update(id, params)

--- a/lib/mollie_pay.rb
+++ b/lib/mollie_pay.rb
@@ -1,4 +1,5 @@
 require "mollie-api-ruby"
+require "mollie/sales_invoice"
 require "mollie_pay/version"
 require "mollie_pay/errors"
 require "mollie_pay/configuration"
@@ -34,4 +35,84 @@ module MolliePay
   def self.payment_method(id, **options)
     Mollie::Method.get(id, options)
   end
+
+  # Create a sales invoice on Mollie (beta).
+  # Accepts snake_case Ruby hashes — keys are camelized before sending.
+  # Line item unit_price accepts cents (integer) and is converted to Mollie format.
+  #
+  #   MolliePay.create_sales_invoice(
+  #     status: "issued",
+  #     recipient: { type: "consumer", given_name: "Jane", family_name: "Doe", email: "jane@example.com" },
+  #     lines: [{ description: "Pro plan", quantity: 1, vat_rate: "21.00", unit_price: 8900 }],
+  #     email_details: { subject: "Your invoice", body: "Please pay" }
+  #   )
+  #
+  def self.create_sales_invoice(status:, recipient:, lines:, **options)
+    params = deep_camelize_keys(options)
+    params[:status] = status
+    params[:recipient] = deep_camelize_keys(recipient)
+    params[:lines] = lines.map { |line| build_sales_invoice_line(line) }
+    Mollie::SalesInvoice.create(params, idempotency_key: SecureRandom.uuid)
+  end
+
+  # Get a single sales invoice by ID.
+  #
+  #   MolliePay.sales_invoice("invoice_abc123")
+  #
+  def self.sales_invoice(id)
+    Mollie::SalesInvoice.get(id)
+  end
+
+  # List all sales invoices.
+  #
+  #   MolliePay.sales_invoices
+  #
+  def self.sales_invoices(**options)
+    Mollie::SalesInvoice.all(options)
+  end
+
+  # Update a sales invoice.
+  #
+  #   MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated memo")
+  #
+  def self.update_sales_invoice(id, **attrs)
+    params = deep_camelize_keys(attrs)
+    params[:recipient] = deep_camelize_keys(attrs[:recipient]) if attrs[:recipient]
+    params[:lines] = attrs[:lines].map { |line| build_sales_invoice_line(line) } if attrs[:lines]
+    Mollie::SalesInvoice.update(id, params)
+  end
+
+  # Delete a draft sales invoice.
+  #
+  #   MolliePay.delete_sales_invoice("invoice_abc123")
+  #
+  def self.delete_sales_invoice(id)
+    Mollie::SalesInvoice.delete(id)
+  end
+
+  def self.build_sales_invoice_line(line)
+    built = deep_camelize_keys(line)
+    if built[:unitPrice].is_a?(Integer)
+      built[:unitPrice] = {
+        currency: configuration.currency,
+        value:    format("%.2f", built[:unitPrice] / 100.0)
+      }
+    end
+    built
+  end
+  private_class_method :build_sales_invoice_line
+
+  def self.deep_camelize_keys(hash)
+    hash.each_with_object({}) do |(key, value), result|
+      camelized_key = Mollie::Util.camelize(key)
+      result[camelized_key.to_sym] = if value.is_a?(Hash)
+        deep_camelize_keys(value)
+      elsif value.is_a?(Array)
+        value.map { |v| v.is_a?(Hash) ? deep_camelize_keys(v) : v }
+      else
+        value
+      end
+    end
+  end
+  private_class_method :deep_camelize_keys
 end

--- a/lib/mollie_pay/test_fixtures/sales_invoice.json
+++ b/lib/mollie_pay/test_fixtures/sales_invoice.json
@@ -1,0 +1,72 @@
+{
+  "resource": "sales-invoice",
+  "id": "invoice_test1234AB",
+  "profileId": "pfl_testXYZ",
+  "status": "issued",
+  "invoiceNumber": "INV-0000001",
+  "recipientIdentifier": "customer-xyz-0123",
+  "recipient": {
+    "type": "consumer",
+    "givenName": "Jane",
+    "familyName": "Doe",
+    "email": "jane@example.com",
+    "streetAndNumber": "Keizersgracht 126",
+    "postalCode": "1015 CX",
+    "city": "Amsterdam",
+    "country": "NL",
+    "locale": "nl_NL"
+  },
+  "lines": [
+    {
+      "description": "Monthly subscription - Pro plan",
+      "quantity": 1,
+      "vatRate": "21.00",
+      "unitPrice": {
+        "currency": "EUR",
+        "value": "89.00"
+      }
+    }
+  ],
+  "paymentTerm": "30 days",
+  "vatScheme": "standard",
+  "vatMode": "exclusive",
+  "memo": "Thank you for your business!",
+  "isEInvoice": false,
+  "subtotalAmount": {
+    "currency": "EUR",
+    "value": "89.00"
+  },
+  "discountedSubtotalAmount": {
+    "currency": "EUR",
+    "value": "89.00"
+  },
+  "totalVatAmount": {
+    "currency": "EUR",
+    "value": "18.69"
+  },
+  "totalAmount": {
+    "currency": "EUR",
+    "value": "107.69"
+  },
+  "amountDue": {
+    "currency": "EUR",
+    "value": "107.69"
+  },
+  "createdAt": "2026-03-26T10:00:00+00:00",
+  "issuedAt": "2026-03-26T10:00:00+00:00",
+  "dueAt": "2026-04-25T10:00:00+00:00",
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/sales-invoices/invoice_test1234AB",
+      "type": "application/hal+json"
+    },
+    "pdfLink": {
+      "href": "https://api.mollie.com/v2/sales-invoices/invoice_test1234AB/pdf",
+      "type": "application/pdf"
+    },
+    "invoicePayment": {
+      "href": "https://pay.mollie.com/invoice/test1234AB",
+      "type": "text/html"
+    }
+  }
+}

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -168,6 +168,45 @@ module MolliePay
       OpenStruct.new(id: id, status: status)
     end
 
+    # Build a fake Mollie sales invoice response (OpenStruct).
+    def fake_mollie_sales_invoice(id: nil, status: "draft")
+      id ||= "invoice_test#{SecureRandom.hex(4)}"
+      OpenStruct.new(
+        id: id,
+        status: status,
+        invoice_number: nil,
+        recipient_identifier: nil
+      )
+    end
+
+    # Stub Mollie::SalesInvoice.create.
+    #
+    #   stub_mollie_sales_invoice_create do
+    #     invoice = MolliePay.create_sales_invoice(
+    #       status: "draft",
+    #       recipient: { type: "consumer", given_name: "Jane" },
+    #       lines: [{ description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 }]
+    #     )
+    #     assert_equal "draft", invoice.status
+    #   end
+    #
+    def stub_mollie_sales_invoice_create(**overrides, &block)
+      response = fake_mollie_sales_invoice(**overrides)
+      Mollie::SalesInvoice.stub(:create, response, &block)
+    end
+
+    # Stub Mollie::SalesInvoice.get.
+    #
+    #   stub_mollie_sales_invoice_get do
+    #     invoice = MolliePay.sales_invoice("invoice_abc123")
+    #     assert_equal "issued", invoice.status
+    #   end
+    #
+    def stub_mollie_sales_invoice_get(**overrides, &block)
+      response = fake_mollie_sales_invoice(**overrides)
+      Mollie::SalesInvoice.stub(:get, response, &block)
+    end
+
     # ── WebMock-based API stubs ────────────────────────────────────────
     #
     # These stub the actual HTTP endpoints that the Mollie SDK calls.
@@ -287,6 +326,36 @@ module MolliePay
     def webmock_mollie_payment_get(payment_id, **overrides)
       body = mollie_fixture("payment", id: payment_id, **overrides)
       stub_request(:get, "#{MOLLIE_API_BASE}/payments/#{payment_id}")
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/hal+json" })
+      yield
+    ensure
+      WebMock.reset!
+    end
+
+    # Stub POST /v2/sales-invoices.
+    #
+    #   webmock_mollie_sales_invoice_create do
+    #     invoice = MolliePay.create_sales_invoice(...)
+    #   end
+    #
+    def webmock_mollie_sales_invoice_create(**overrides)
+      body = mollie_fixture("sales_invoice", **overrides)
+      stub_request(:post, "#{MOLLIE_API_BASE}/sales-invoices")
+        .to_return(status: 201, body: body, headers: { "Content-Type" => "application/hal+json" })
+      yield
+    ensure
+      WebMock.reset!
+    end
+
+    # Stub GET /v2/sales-invoices/:id.
+    #
+    #   webmock_mollie_sales_invoice_get("invoice_abc123") do
+    #     invoice = MolliePay.sales_invoice("invoice_abc123")
+    #   end
+    #
+    def webmock_mollie_sales_invoice_get(invoice_id, **overrides)
+      body = mollie_fixture("sales_invoice", id: invoice_id, **overrides)
+      stub_request(:get, "#{MOLLIE_API_BASE}/sales-invoices/#{invoice_id}")
         .to_return(status: 200, body: body, headers: { "Content-Type" => "application/hal+json" })
       yield
     ensure

--- a/test/lib/mollie/sales_invoice_test.rb
+++ b/test/lib/mollie/sales_invoice_test.rb
@@ -44,6 +44,9 @@ class Mollie::SalesInvoiceTest < ActiveSupport::TestCase
     assert_instance_of Mollie::Amount, invoice.subtotal_amount
     assert_equal BigDecimal("89.00"), invoice.subtotal_amount.value
 
+    assert_instance_of Mollie::Amount, invoice.discounted_subtotal_amount
+    assert_equal BigDecimal("89.00"), invoice.discounted_subtotal_amount.value
+
     assert_instance_of Mollie::Amount, invoice.total_vat_amount
     assert_equal BigDecimal("18.69"), invoice.total_vat_amount.value
 
@@ -54,13 +57,18 @@ class Mollie::SalesInvoiceTest < ActiveSupport::TestCase
     assert_equal BigDecimal("107.69"), invoice.amount_due.value
   end
 
-  test "timestamp fields are parsed to Time" do
+  test "timestamp fields are parsed to Time with correct values" do
     invoice = Mollie::SalesInvoice.new(api_response_hash)
 
-    assert_instance_of Time, invoice.created_at
-    assert_instance_of Time, invoice.issued_at
-    assert_instance_of Time, invoice.due_at
+    assert_equal Time.parse("2026-03-26T10:00:00+00:00"), invoice.created_at
+    assert_equal Time.parse("2026-03-26T10:00:00+00:00"), invoice.issued_at
+    assert_equal Time.parse("2026-04-25T10:00:00+00:00"), invoice.due_at
     assert_nil invoice.paid_at
+  end
+
+  test "timestamp setters return nil for unparseable values" do
+    invoice = Mollie::SalesInvoice.new("created_at" => "not-a-date")
+    assert_nil invoice.created_at
   end
 
   test "recipient is converted to OpenStruct" do
@@ -133,6 +141,7 @@ class Mollie::SalesInvoiceTest < ActiveSupport::TestCase
         "memo" => "Thank you!",
         "is_e_invoice" => false,
         "subtotal_amount" => { "currency" => "EUR", "value" => "89.00" },
+        "discounted_subtotal_amount" => { "currency" => "EUR", "value" => "89.00" },
         "total_vat_amount" => { "currency" => "EUR", "value" => "18.69" },
         "total_amount" => { "currency" => "EUR", "value" => "107.69" },
         "amount_due" => { "currency" => "EUR", "value" => "107.69" },

--- a/test/lib/mollie/sales_invoice_test.rb
+++ b/test/lib/mollie/sales_invoice_test.rb
@@ -1,0 +1,149 @@
+require "test_helper"
+
+class Mollie::SalesInvoiceTest < ActiveSupport::TestCase
+  test "resource_name returns sales-invoices" do
+    assert_equal "sales-invoices", Mollie::SalesInvoice.resource_name
+  end
+
+  test "initializes from API response hash" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+
+    assert_equal "invoice_abc123", invoice.id
+    assert_equal "issued", invoice.status
+    assert_equal "INV-0000001", invoice.invoice_number
+    assert_equal "profile_xyz", invoice.profile_id
+    assert_equal "customer-xyz-0123", invoice.recipient_identifier
+    assert_equal "30 days", invoice.payment_term
+    assert_equal "standard", invoice.vat_scheme
+    assert_equal "exclusive", invoice.vat_mode
+    assert_equal "Thank you!", invoice.memo
+    assert_equal false, invoice.is_e_invoice
+  end
+
+  test "status predicates" do
+    draft = Mollie::SalesInvoice.new("status" => "draft")
+    assert draft.draft?
+    assert_not draft.issued?
+    assert_not draft.paid?
+    assert_not draft.canceled?
+
+    issued = Mollie::SalesInvoice.new("status" => "issued")
+    assert issued.issued?
+    assert_not issued.draft?
+
+    paid = Mollie::SalesInvoice.new("status" => "paid")
+    assert paid.paid?
+
+    canceled = Mollie::SalesInvoice.new("status" => "canceled")
+    assert canceled.canceled?
+  end
+
+  test "amount fields are converted to Mollie::Amount" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+
+    assert_instance_of Mollie::Amount, invoice.subtotal_amount
+    assert_equal BigDecimal("89.00"), invoice.subtotal_amount.value
+
+    assert_instance_of Mollie::Amount, invoice.total_vat_amount
+    assert_equal BigDecimal("18.69"), invoice.total_vat_amount.value
+
+    assert_instance_of Mollie::Amount, invoice.total_amount
+    assert_equal BigDecimal("107.69"), invoice.total_amount.value
+
+    assert_instance_of Mollie::Amount, invoice.amount_due
+    assert_equal BigDecimal("107.69"), invoice.amount_due.value
+  end
+
+  test "timestamp fields are parsed to Time" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+
+    assert_instance_of Time, invoice.created_at
+    assert_instance_of Time, invoice.issued_at
+    assert_instance_of Time, invoice.due_at
+    assert_nil invoice.paid_at
+  end
+
+  test "recipient is converted to OpenStruct" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+
+    assert_instance_of OpenStruct, invoice.recipient
+    assert_equal "consumer", invoice.recipient.type
+    assert_equal "Jane", invoice.recipient.given_name
+    assert_equal "Doe", invoice.recipient.family_name
+  end
+
+  test "metadata is converted to OpenStruct" do
+    invoice = Mollie::SalesInvoice.new(
+      "metadata" => { "order_id" => "ord_123" }
+    )
+
+    assert_instance_of OpenStruct, invoice.metadata
+    assert_equal "ord_123", invoice.metadata.order_id
+  end
+
+  test "pdf_url extracts from links" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+    assert_equal "https://api.mollie.com/v2/sales-invoices/invoice_abc123/pdf", invoice.pdf_url
+  end
+
+  test "payment_url extracts from links" do
+    invoice = Mollie::SalesInvoice.new(api_response_hash)
+    assert_equal "https://pay.mollie.com/invoice/abc123", invoice.payment_url
+  end
+
+  test "pdf_url returns nil when no links" do
+    invoice = Mollie::SalesInvoice.new("status" => "draft")
+    assert_nil invoice.pdf_url
+  end
+
+  test "CRUD methods are inherited from Base" do
+    assert_respond_to Mollie::SalesInvoice, :create
+    assert_respond_to Mollie::SalesInvoice, :get
+    assert_respond_to Mollie::SalesInvoice, :all
+    assert_respond_to Mollie::SalesInvoice, :update
+    assert_respond_to Mollie::SalesInvoice, :delete
+  end
+
+  private
+
+    def api_response_hash
+      {
+        "id" => "invoice_abc123",
+        "profile_id" => "profile_xyz",
+        "status" => "issued",
+        "invoice_number" => "INV-0000001",
+        "recipient_identifier" => "customer-xyz-0123",
+        "recipient" => {
+          "type" => "consumer",
+          "given_name" => "Jane",
+          "family_name" => "Doe",
+          "email" => "jane@example.com"
+        },
+        "lines" => [
+          {
+            "description" => "Monthly subscription",
+            "quantity" => 1,
+            "vat_rate" => "21.00",
+            "unit_price" => { "currency" => "EUR", "value" => "89.00" }
+          }
+        ],
+        "payment_term" => "30 days",
+        "vat_scheme" => "standard",
+        "vat_mode" => "exclusive",
+        "memo" => "Thank you!",
+        "is_e_invoice" => false,
+        "subtotal_amount" => { "currency" => "EUR", "value" => "89.00" },
+        "total_vat_amount" => { "currency" => "EUR", "value" => "18.69" },
+        "total_amount" => { "currency" => "EUR", "value" => "107.69" },
+        "amount_due" => { "currency" => "EUR", "value" => "107.69" },
+        "created_at" => "2026-03-26T10:00:00+00:00",
+        "issued_at" => "2026-03-26T10:00:00+00:00",
+        "due_at" => "2026-04-25T10:00:00+00:00",
+        "_links" => {
+          "self" => { "href" => "https://api.mollie.com/v2/sales-invoices/invoice_abc123" },
+          "pdf_link" => { "href" => "https://api.mollie.com/v2/sales-invoices/invoice_abc123/pdf" },
+          "invoice_payment" => { "href" => "https://pay.mollie.com/invoice/abc123" }
+        }
+      }
+    end
+end

--- a/test/lib/mollie_pay/sales_invoices_test.rb
+++ b/test/lib/mollie_pay/sales_invoices_test.rb
@@ -128,11 +128,12 @@ class MolliePay::SalesInvoicesTest < ActiveSupport::TestCase
     fake_update = ->(id, data) { called_with_id = id; called_with_data = data; fake_invoice }
 
     Mollie::SalesInvoice.stub(:update, fake_update) do
-      MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated")
+      MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated", payment_term: "14 days")
     end
 
     assert_equal "invoice_abc123", called_with_id
     assert_equal "Updated", called_with_data[:memo]
+    assert_equal "14 days", called_with_data[:paymentTerm]
   end
 
   test "update_sales_invoice camelizes nested recipient" do

--- a/test/lib/mollie_pay/sales_invoices_test.rb
+++ b/test/lib/mollie_pay/sales_invoices_test.rb
@@ -1,0 +1,181 @@
+require "test_helper"
+
+class MolliePay::SalesInvoicesTest < ActiveSupport::TestCase
+  test "create_sales_invoice passes correct params to SDK" do
+    received_data = nil
+    received_options = nil
+    fake_create = ->(data, options) { received_data = data; received_options = options; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:create, fake_create) do
+      MolliePay.create_sales_invoice(
+        status: "issued",
+        recipient: { type: "consumer", given_name: "Jane", family_name: "Doe", email: "jane@example.com" },
+        lines: [ { description: "Pro plan", quantity: 1, vat_rate: "21.00", unit_price: 8900 } ],
+        email_details: { subject: "Your invoice", body: "Please pay" }
+      )
+    end
+
+    assert_equal "issued", received_data[:status]
+    assert_equal({ type: "consumer", givenName: "Jane", familyName: "Doe", email: "jane@example.com" }, received_data[:recipient])
+    assert_equal "Pro plan", received_data[:lines].first[:description]
+    assert_equal({ subject: "Your invoice", body: "Please pay" }, received_data[:emailDetails])
+    assert received_options[:idempotency_key].present?
+  end
+
+  test "create_sales_invoice converts line item unit_price from cents" do
+    received_data = nil
+    fake_create = ->(data, _options) { received_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:create, fake_create) do
+      MolliePay.create_sales_invoice(
+        status: "draft",
+        recipient: { type: "consumer", given_name: "Jane" },
+        lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 8900 } ]
+      )
+    end
+
+    line = received_data[:lines].first
+    assert_equal({ currency: "EUR", value: "89.00" }, line[:unitPrice])
+  end
+
+  test "create_sales_invoice passes hash unit_price as-is" do
+    received_data = nil
+    fake_create = ->(data, _options) { received_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:create, fake_create) do
+      MolliePay.create_sales_invoice(
+        status: "draft",
+        recipient: { type: "consumer", given_name: "Jane" },
+        lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: { currency: "EUR", value: "89.00" } } ]
+      )
+    end
+
+    line = received_data[:lines].first
+    assert_equal({ currency: "EUR", value: "89.00" }, line[:unitPrice])
+  end
+
+  test "create_sales_invoice camelizes recipient keys" do
+    received_data = nil
+    fake_create = ->(data, _options) { received_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:create, fake_create) do
+      MolliePay.create_sales_invoice(
+        status: "draft",
+        recipient: {
+          type: "business",
+          organization_name: "Acme B.V.",
+          vat_number: "NL123456789B01",
+          street_and_number: "Keizersgracht 126",
+          postal_code: "1015 CX",
+          city: "Amsterdam",
+          country: "NL"
+        },
+        lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ]
+      )
+    end
+
+    recipient = received_data[:recipient]
+    assert_equal "business", recipient[:type]
+    assert_equal "Acme B.V.", recipient[:organizationName]
+    assert_equal "NL123456789B01", recipient[:vatNumber]
+    assert_equal "Keizersgracht 126", recipient[:streetAndNumber]
+    assert_equal "1015 CX", recipient[:postalCode]
+  end
+
+  test "create_sales_invoice forwards payment_details and payment_term" do
+    received_data = nil
+    fake_create = ->(data, _options) { received_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:create, fake_create) do
+      MolliePay.create_sales_invoice(
+        status: "paid",
+        recipient: { type: "consumer", given_name: "Jane" },
+        lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ],
+        payment_term: "30 days",
+        payment_details: { source: "manual" }
+      )
+    end
+
+    assert_equal "30 days", received_data[:paymentTerm]
+    assert_equal({ source: "manual" }, received_data[:paymentDetails])
+  end
+
+  test "sales_invoice delegates to Mollie::SalesInvoice.get" do
+    called_with_id = nil
+    fake_get = ->(id) { called_with_id = id; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:get, fake_get) do
+      MolliePay.sales_invoice("invoice_abc123")
+    end
+
+    assert_equal "invoice_abc123", called_with_id
+  end
+
+  test "sales_invoices delegates to Mollie::SalesInvoice.all" do
+    called_with = nil
+    fake_all = ->(options) { called_with = options; [] }
+
+    Mollie::SalesInvoice.stub(:all, fake_all) do
+      MolliePay.sales_invoices(limit: 10)
+    end
+
+    assert_equal({ limit: 10 }, called_with)
+  end
+
+  test "update_sales_invoice delegates to Mollie::SalesInvoice.update" do
+    called_with_id = nil
+    called_with_data = nil
+    fake_update = ->(id, data) { called_with_id = id; called_with_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:update, fake_update) do
+      MolliePay.update_sales_invoice("invoice_abc123", memo: "Updated")
+    end
+
+    assert_equal "invoice_abc123", called_with_id
+    assert_equal "Updated", called_with_data[:memo]
+  end
+
+  test "update_sales_invoice camelizes nested recipient" do
+    called_with_data = nil
+    fake_update = ->(_id, data) { called_with_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:update, fake_update) do
+      MolliePay.update_sales_invoice("invoice_abc123",
+        recipient: { given_name: "Updated Jane" }
+      )
+    end
+
+    assert_equal "Updated Jane", called_with_data[:recipient][:givenName]
+  end
+
+  test "update_sales_invoice converts line item unit_price" do
+    called_with_data = nil
+    fake_update = ->(_id, data) { called_with_data = data; fake_invoice }
+
+    Mollie::SalesInvoice.stub(:update, fake_update) do
+      MolliePay.update_sales_invoice("invoice_abc123",
+        lines: [ { description: "New item", quantity: 2, vat_rate: "21.00", unit_price: 5000 } ]
+      )
+    end
+
+    line = called_with_data[:lines].first
+    assert_equal({ currency: "EUR", value: "50.00" }, line[:unitPrice])
+  end
+
+  test "delete_sales_invoice delegates to Mollie::SalesInvoice.delete" do
+    called_with_id = nil
+    fake_delete = ->(id) { called_with_id = id; nil }
+
+    Mollie::SalesInvoice.stub(:delete, fake_delete) do
+      MolliePay.delete_sales_invoice("invoice_abc123")
+    end
+
+    assert_equal "invoice_abc123", called_with_id
+  end
+
+  private
+
+    def fake_invoice
+      OpenStruct.new(id: "invoice_abc123", status: "draft")
+    end
+end

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -857,6 +857,89 @@ module MolliePay
       end
     end
 
+    # === Sales Invoices (beta) ===
+
+    test "mollie_create_sales_invoice auto-populates consumer recipient from billable" do
+      received_recipient = nil
+      fake_create = ->(**args) {
+        received_recipient = args[:recipient]
+        OpenStruct.new(id: "invoice_test", status: "draft")
+      }
+
+      MolliePay.stub(:create_sales_invoice, fake_create) do
+        @org.mollie_create_sales_invoice(
+          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ]
+        )
+      end
+
+      assert_equal "consumer", received_recipient[:type]
+      assert_equal "Acme Corp", received_recipient[:given_name]
+      assert_equal "billing@acme.nl", received_recipient[:email]
+    end
+
+    test "mollie_create_sales_invoice explicit recipient overrides auto-populated" do
+      received_recipient = nil
+      fake_create = ->(**args) {
+        received_recipient = args[:recipient]
+        OpenStruct.new(id: "invoice_test", status: "draft")
+      }
+
+      explicit = { type: "business", organization_name: "Override B.V.", email: "override@test.nl" }
+
+      MolliePay.stub(:create_sales_invoice, fake_create) do
+        @org.mollie_create_sales_invoice(
+          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ],
+          recipient: explicit
+        )
+      end
+
+      assert_equal "business", received_recipient[:type]
+      assert_equal "Override B.V.", received_recipient[:organization_name]
+    end
+
+    test "mollie_create_sales_invoice passes status and options" do
+      received_args = nil
+      fake_create = ->(**args) {
+        received_args = args
+        OpenStruct.new(id: "invoice_test", status: "issued")
+      }
+
+      MolliePay.stub(:create_sales_invoice, fake_create) do
+        @org.mollie_create_sales_invoice(
+          status: "issued",
+          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ],
+          memo: "Thank you!",
+          email_details: { subject: "Invoice", body: "Please pay" }
+        )
+      end
+
+      assert_equal "issued", received_args[:status]
+      assert_equal "Thank you!", received_args[:memo]
+      assert_equal({ subject: "Invoice", body: "Please pay" }, received_args[:email_details])
+    end
+
+    test "mollie_sales_invoices delegates to MolliePay" do
+      called_with = nil
+      fake_all = ->(**options) { called_with = options; [] }
+
+      MolliePay.stub(:sales_invoices, fake_all) do
+        @org.mollie_sales_invoices(limit: 5)
+      end
+
+      assert_equal({ limit: 5 }, called_with)
+    end
+
+    test "mollie_sales_invoice delegates to MolliePay" do
+      called_with_id = nil
+      fake_get = ->(id) { called_with_id = id; OpenStruct.new(id: id, status: "draft") }
+
+      MolliePay.stub(:sales_invoice, fake_get) do
+        @org.mollie_sales_invoice("invoice_abc123")
+      end
+
+      assert_equal "invoice_abc123", called_with_id
+    end
+
     test "mollie_refund raises error for payment not belonging to this customer" do
       other_org = Organization.create!(name: "Other Org", email: "other@org.nl")
       other_customer = MolliePay::Customer.create!(mollie_id: "cst_other", owner: other_org)


### PR DESCRIPTION
## Summary

- Add support for Mollie's Sales Invoices API (beta) — create, retrieve, update, delete, and list sales invoices
- Implements `Mollie::SalesInvoice` SDK extension class mapping to `/v2/sales-invoices` endpoint
- Adds `MolliePay.create_sales_invoice`, `.sales_invoice`, `.sales_invoices`, `.update_sales_invoice`, `.delete_sales_invoice` class methods with deep key camelization and cents-to-Mollie amount conversion
- Adds Billable convenience methods with recipient auto-population from model attributes
- Includes test helpers, JSON fixture, and README documentation

No local model or migration — all state lives on Mollie's side. This follows the class-method-only pattern (like `payment_methods`).

## Key decisions

- **SDK extension in-gem**: `Mollie::SalesInvoice` lives in `lib/mollie/` since the upstream SDK doesn't have this class yet
- **Deep camelization**: The SDK only camelizes top-level keys for most nested objects. A `deep_camelize_keys` helper converts snake_case Ruby hashes to camelCase for `recipient`, `email_details`, `payment_details`
- **No local model**: Deferred until webhook support for sales invoices is available via API keys (currently requires OAuth)

## Test plan

- [x] 223 tests, 466 assertions, 0 failures
- [x] Rubocop clean (0 offenses)
- [x] `Mollie::SalesInvoice` SDK extension: resource_name, attributes, status predicates, amount conversion, timestamp parsing, link helpers
- [x] `MolliePay` module methods: CRUD delegation, amount conversion, key camelization, recipient camelization
- [x] Billable concern: recipient auto-population, delegation, explicit recipient override
- [x] Test helpers: fake objects, stub helpers, WebMock helpers, JSON fixture

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a new additive feature with no local state, no migrations, and no webhook processing changes. All operations are pass-through to the Mollie API.

Closes #69