### PR TITLE
feat(mandates): Add mandate create and revoke operations

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -61,6 +61,34 @@ module MolliePay
       create_mollie_payment(amount:, description:, redirect_url:, method:, metadata:, sequence_type: "first")
     end
 
+    # === Mandates ===
+
+    def mollie_create_mandate(method:, consumer_name:, consumer_account:, **options)
+      customer = mollie_customer!
+
+      mollie_mandate = Mollie::Customer::Mandate.create(
+        customer_id:     customer.mollie_id,
+        method:          method,
+        consumerName:    consumer_name,
+        consumerAccount: consumer_account,
+        **options,
+        idempotency_key: SecureRandom.uuid
+      )
+
+      Mandate.record_from_mollie_mandate(mollie_mandate, customer)
+    end
+
+    def mollie_revoke_mandate(mandate)
+      Mollie::Customer::Mandate.delete(
+        mandate.mollie_id,
+        customer_id: mollie_customer.mollie_id
+      )
+      mandate.update!(status: "invalid")
+      mandate
+    end
+
+    # === Subscriptions ===
+
     def mollie_subscribe(amount:, interval:, description:, start_date: nil, name: "default")
       raise MolliePay::MandateRequired, "No valid mandate on file" unless mollie_mandated?
 

--- a/app/models/mollie_pay/mandate.rb
+++ b/app/models/mollie_pay/mandate.rb
@@ -11,6 +11,21 @@ module MolliePay
     scope :valid_status, -> { where(status: "valid") }
     scope :pending,      -> { where(status: "pending") }
 
+    def self.record_from_mollie_mandate(mollie_mandate, customer)
+      mandate = find_or_initialize_by(mollie_id: mollie_mandate.id)
+      was_valid = mandate.valid_status?
+
+      mandate.update!(
+        customer:    customer,
+        status:      mollie_mandate.status,
+        method:      mollie_mandate.method,
+        mandated_at: mollie_mandate.status == "valid" && !was_valid ? Time.current : mandate.mandated_at
+      )
+
+      customer.owner.on_mollie_mandate_created(mandate) if mandate.valid_status? && !was_valid
+      mandate
+    end
+
     def self.record_from_mollie_payment(payment, mollie_payment = nil)
       mollie_payment ||= payment.mollie_record
       return unless mollie_payment.mandate_id

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -118,6 +118,31 @@ module MolliePay
       Mollie::Customer.stub(:delete, nil, &block)
     end
 
+    # Stub Mollie::Customer::Mandate.create.
+    #
+    #   stub_mollie_mandate_create do
+    #     mandate = @user.mollie_create_mandate(
+    #       method: "directdebit", consumer_name: "John Doe",
+    #       consumer_account: "NL55INGB0000000000"
+    #     )
+    #     assert_equal "valid", mandate.status
+    #   end
+    #
+    def stub_mollie_mandate_create(**overrides, &block)
+      response = fake_mollie_mandate(**overrides)
+      Mollie::Customer::Mandate.stub(:create, response, &block)
+    end
+
+    # Stub Mollie::Customer::Mandate.delete.
+    #
+    #   stub_mollie_mandate_revoke do
+    #     @user.mollie_revoke_mandate(mandate)
+    #   end
+    #
+    def stub_mollie_mandate_revoke(&block)
+      Mollie::Customer::Mandate.stub(:delete, nil, &block)
+    end
+
     # Stub Mollie::Refund.create.
     #
     #   stub_mollie_refund_create do
@@ -174,6 +199,12 @@ module MolliePay
     def fake_mollie_customer(id: nil)
       id ||= "cst_test#{SecureRandom.hex(4)}"
       OpenStruct.new(id: id)
+    end
+
+    # Build a fake Mollie mandate response (OpenStruct).
+    def fake_mollie_mandate(id: nil, status: "valid", method: "directdebit")
+      id ||= "mdt_test#{SecureRandom.hex(4)}"
+      OpenStruct.new(id: id, status: status, method: method)
     end
 
     # Build a fake Mollie subscription response (OpenStruct).

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -413,6 +413,104 @@ module MolliePay
       assert_equal @org.mollie_customer.mollie_id, received_options[:customer_id]
     end
 
+    # === Mandate create & revoke ===
+
+    test "mollie_create_mandate creates mandate on Mollie and persists locally" do
+      stub_mollie_mandate_create(id: "mdt_new123") do
+        mandate = @org.mollie_create_mandate(
+          method: "directdebit",
+          consumer_name: "Acme Corp",
+          consumer_account: "NL55INGB0000000000"
+        )
+
+        assert_equal "mdt_new123", mandate.mollie_id
+        assert_equal "valid", mandate.status
+        assert_equal "directdebit", mandate.method
+        assert_equal @org.mollie_customer, mandate.customer
+        assert_not_nil mandate.mandated_at
+      end
+    end
+
+    test "mollie_create_mandate creates customer if none exists" do
+      org = Organization.create!(name: "Fresh Org", email: "fresh@org.nl")
+      assert_nil org.mollie_customer
+
+      customer_response = fake_mollie_customer(id: "cst_fresh_mdt")
+      mandate_response  = fake_mollie_mandate(id: "mdt_fresh123")
+
+      Mollie::Customer.stub(:create, customer_response) do
+        Mollie::Customer::Mandate.stub(:create, mandate_response) do
+          mandate = org.mollie_create_mandate(
+            method: "directdebit",
+            consumer_name: "Fresh Org",
+            consumer_account: "NL55INGB0000000000"
+          )
+
+          assert_not_nil org.reload.mollie_customer
+          assert_equal "cst_fresh_mdt", org.mollie_customer.mollie_id
+          assert_equal "mdt_fresh123", mandate.mollie_id
+        end
+      end
+    end
+
+    test "mollie_create_mandate fires on_mollie_mandate_created for valid mandates" do
+      hook_called = false
+      @org.define_singleton_method(:on_mollie_mandate_created) { |_m| hook_called = true }
+
+      stub_mollie_mandate_create(id: "mdt_hook123", status: "valid") do
+        @org.mollie_create_mandate(
+          method: "directdebit",
+          consumer_name: "Acme Corp",
+          consumer_account: "NL55INGB0000000000"
+        )
+      end
+
+      assert hook_called, "on_mollie_mandate_created should have been called"
+    end
+
+    test "mollie_create_mandate sends idempotency key" do
+      received_args = nil
+      response = fake_mollie_mandate(id: "mdt_idem123")
+      fake_create = ->(**args) { received_args = args; response }
+
+      Mollie::Customer::Mandate.stub(:create, fake_create) do
+        @org.mollie_create_mandate(
+          method: "directdebit",
+          consumer_name: "Acme Corp",
+          consumer_account: "NL55INGB0000000000"
+        )
+      end
+
+      assert received_args[:idempotency_key].present?, "idempotency_key should be present"
+      assert_match(/\A[0-9a-f-]{36}\z/, received_args[:idempotency_key])
+    end
+
+    test "mollie_revoke_mandate calls Mollie API and updates status to invalid" do
+      mandate = mollie_pay_mandates(:acme_mandate)
+      assert_equal "valid", mandate.status
+
+      stub_mollie_mandate_revoke do
+        result = @org.mollie_revoke_mandate(mandate)
+        assert_equal mandate, result
+      end
+
+      assert_equal "invalid", mandate.reload.status
+    end
+
+    test "mollie_revoke_mandate works with correct customer_id" do
+      mandate = mollie_pay_mandates(:acme_mandate)
+      received_id = nil
+      received_options = nil
+      fake_delete = ->(id, **opts) { received_id = id; received_options = opts; nil }
+
+      Mollie::Customer::Mandate.stub(:delete, fake_delete) do
+        @org.mollie_revoke_mandate(mandate)
+      end
+
+      assert_equal mandate.mollie_id, received_id
+      assert_equal @org.mollie_customer.mollie_id, received_options[:customer_id]
+    end
+
     # === Named subscriptions ===
 
     test "mollie_subscribe creates named subscription" do

--- a/test/models/mollie_pay/mandate_test.rb
+++ b/test/models/mollie_pay/mandate_test.rb
@@ -22,6 +22,39 @@ module MolliePay
       assert_not mandate.valid?
     end
 
+    test "record_from_mollie_mandate creates new mandate from Mollie object" do
+      customer = mollie_pay_customers(:acme)
+      mollie_mandate = OpenStruct.new(
+        id:     "mdt_brand_new",
+        status: "valid",
+        method: "directdebit"
+      )
+
+      mandate = Mandate.record_from_mollie_mandate(mollie_mandate, customer)
+
+      assert_equal "mdt_brand_new", mandate.mollie_id
+      assert_equal "valid", mandate.status
+      assert_equal "directdebit", mandate.method
+      assert_equal customer, mandate.customer
+      assert_not_nil mandate.mandated_at
+    end
+
+    test "record_from_mollie_mandate updates existing mandate" do
+      existing = mollie_pay_mandates(:acme_mandate)
+      customer = existing.customer
+      mollie_mandate = OpenStruct.new(
+        id:     existing.mollie_id,
+        status: "invalid",
+        method: "creditcard"
+      )
+
+      mandate = Mandate.record_from_mollie_mandate(mollie_mandate, customer)
+
+      assert_equal existing.id, mandate.id
+      assert_equal "invalid", mandate.status
+      assert_equal "creditcard", mandate.method
+    end
+
     test "record_from_mollie_payment creates mandate from first payment" do
       payment = mollie_pay_payments(:acme_first)
 


### PR DESCRIPTION
## Summary

- Add `mollie_create_mandate(method:, consumer_name:, consumer_account:)` for direct SEPA DD mandate creation
- Add `mollie_revoke_mandate(mandate)` to revoke mandates on Mollie and update local status
- Add `Mandate.record_from_mollie_mandate` class method for persisting mandates from API responses
- Add test helpers: `fake_mollie_mandate`, `stub_mollie_mandate_create`, `stub_mollie_mandate_revoke`

Enables SEPA Direct Debit merchants to create mandates without going through the first-payment flow, and revoke mandates for GDPR compliance.

## Test plan

- [x] 231 tests passing, rubocop clean
- [x] Create mandate: persists locally, creates customer if none, fires hook, sends idempotency key
- [x] Revoke mandate: calls API, updates local status to invalid
- [x] `record_from_mollie_mandate`: creates new and updates existing

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: additive Billable methods, no changes to existing mandate behavior.

Closes #78