### PR TITLE
feat(sales-invoices): Add SalesInvoice ActiveRecord model with record_from_mollie

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -258,6 +258,8 @@ module MolliePay
     def on_mollie_chargeback_received(chargeback)  ; end
     def on_mollie_chargeback_reversed(chargeback)  ; end
     def on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:) ; end
+    def on_mollie_sales_invoice_issued(sales_invoice) ; end
+    def on_mollie_sales_invoice_paid(sales_invoice)   ; end
 
     private
 

--- a/app/models/mollie_pay/customer.rb
+++ b/app/models/mollie_pay/customer.rb
@@ -2,9 +2,10 @@ module MolliePay
   class Customer < ApplicationRecord
     belongs_to :owner, polymorphic: true
 
-    has_many :payments,      dependent: :destroy
-    has_many :subscriptions, dependent: :destroy
-    has_many :mandates,      dependent: :destroy
+    has_many :payments,       dependent: :destroy
+    has_many :subscriptions,  dependent: :destroy
+    has_many :mandates,       dependent: :destroy
+    has_many :sales_invoices, dependent: :destroy
 
     validates :mollie_id, presence: true, uniqueness: true
 

--- a/app/models/mollie_pay/sales_invoice.rb
+++ b/app/models/mollie_pay/sales_invoice.rb
@@ -1,0 +1,91 @@
+module MolliePay
+  class SalesInvoice < ApplicationRecord
+    STATUS_DRAFT    = "draft"
+    STATUS_ISSUED   = "issued"
+    STATUS_PAID     = "paid"
+    STATUS_CANCELED = "canceled"
+
+    STATUSES = [ STATUS_DRAFT, STATUS_ISSUED, STATUS_PAID, STATUS_CANCELED ].freeze
+
+    belongs_to :customer
+
+    validates :mollie_id, presence: true, uniqueness: true
+    validates :status,    inclusion: { in: STATUSES }
+    validates :amount,    numericality: { greater_than: 0 }, allow_nil: true
+    validates :currency,  presence: true, allow_nil: true
+
+    scope :draft,   -> { where(status: STATUS_DRAFT) }
+    scope :issued,  -> { where(status: STATUS_ISSUED) }
+    scope :paid,    -> { where(status: STATUS_PAID) }
+    scope :overdue, -> { where(status: STATUS_ISSUED).where("due_at < ?", Time.current) }
+
+    def self.record_from_mollie(mollie_si, customer)
+      invoice = find_or_initialize_by(mollie_id: mollie_si.id)
+      previous_status = invoice.status
+
+      amount_cents = mollie_si.total_amount ? mollie_value_to_cents(mollie_si.total_amount) : nil
+      currency     = mollie_si.total_amount&.currency
+
+      invoice.update!(
+        customer:             customer,
+        status:               mollie_si.status,
+        invoice_number:       mollie_si.invoice_number,
+        amount:               amount_cents,
+        currency:             currency,
+        recipient_identifier: mollie_si.recipient_identifier,
+        memo:                 mollie_si.memo,
+        issued_at:            mollie_si.issued_at,
+        paid_at:              mollie_si.paid_at,
+        due_at:               mollie_si.due_at
+      )
+
+      if invoice.status != previous_status
+        notify_billable(invoice, previous_status)
+      end
+
+      invoice
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(mollie_id: mollie_si.id)
+    end
+
+    def mollie_record
+      Mollie::SalesInvoice.get(mollie_id)
+    end
+
+    def draft?
+      status == STATUS_DRAFT
+    end
+
+    def issued?
+      status == STATUS_ISSUED
+    end
+
+    def paid?
+      status == STATUS_PAID
+    end
+
+    def canceled?
+      status == STATUS_CANCELED
+    end
+
+    def amount_decimal
+      amount / 100.0
+    end
+
+    def mollie_amount
+      { currency: currency, value: format("%.2f", amount_decimal) }
+    end
+
+    private_class_method def self.notify_billable(invoice, previous_status)
+      billable = invoice.customer.owner
+
+      if invoice.status == STATUS_ISSUED && previous_status != STATUS_ISSUED
+        billable.on_mollie_sales_invoice_issued(invoice)
+      end
+
+      if invoice.status == STATUS_PAID && previous_status != STATUS_PAID
+        billable.on_mollie_sales_invoice_paid(invoice)
+      end
+    end
+  end
+end

--- a/db/migrate/20260326000002_create_mollie_pay_sales_invoices.rb
+++ b/db/migrate/20260326000002_create_mollie_pay_sales_invoices.rb
@@ -1,0 +1,19 @@
+class CreateMolliePaySalesInvoices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mollie_pay_sales_invoices do |t|
+      t.references :customer, null: false,
+        foreign_key: { to_table: :mollie_pay_customers }
+      t.string   :mollie_id,             null: false, index: { unique: true }
+      t.string   :status,                null: false, default: "draft"
+      t.string   :invoice_number
+      t.integer  :amount
+      t.string   :currency
+      t.string   :recipient_identifier
+      t.text     :memo
+      t.datetime :issued_at
+      t.datetime :paid_at
+      t.datetime :due_at
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_21_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_26_000002) do
   create_table "mollie_pay_chargebacks", force: :cascade do |t|
     t.integer "amount", null: false
     t.datetime "created_at", null: false
@@ -87,6 +87,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_000001) do
     t.index ["payment_id"], name: "index_mollie_pay_refunds_on_payment_id"
   end
 
+  create_table "mollie_pay_sales_invoices", force: :cascade do |t|
+    t.integer "amount"
+    t.datetime "created_at", null: false
+    t.string "currency"
+    t.integer "customer_id", null: false
+    t.datetime "due_at"
+    t.string "invoice_number"
+    t.datetime "issued_at"
+    t.text "memo"
+    t.string "mollie_id", null: false
+    t.datetime "paid_at"
+    t.string "recipient_identifier"
+    t.string "status", default: "draft", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_mollie_pay_sales_invoices_on_customer_id"
+    t.index ["mollie_id"], name: "index_mollie_pay_sales_invoices_on_mollie_id", unique: true
+  end
+
   create_table "mollie_pay_subscriptions", force: :cascade do |t|
     t.integer "amount", null: false
     t.datetime "canceled_at"
@@ -116,5 +134,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_000001) do
   add_foreign_key "mollie_pay_payments", "mollie_pay_customers", column: "customer_id"
   add_foreign_key "mollie_pay_payments", "mollie_pay_subscriptions", column: "subscription_id"
   add_foreign_key "mollie_pay_refunds", "mollie_pay_payments", column: "payment_id"
+  add_foreign_key "mollie_pay_sales_invoices", "mollie_pay_customers", column: "customer_id"
   add_foreign_key "mollie_pay_subscriptions", "mollie_pay_customers", column: "customer_id"
 end

--- a/test/fixtures/mollie_pay/sales_invoices.yml
+++ b/test/fixtures/mollie_pay/sales_invoices.yml
@@ -1,0 +1,16 @@
+acme_draft:
+  customer: acme
+  mollie_id: invoice_draft123
+  status: draft
+
+acme_issued:
+  customer: acme
+  mollie_id: invoice_issued456
+  status: issued
+  invoice_number: INV-0000001
+  amount: 10769
+  currency: EUR
+  recipient_identifier: cust-xyz
+  memo: Thank you
+  issued_at: 2026-03-01 12:00:00
+  due_at: 2026-03-31 12:00:00

--- a/test/models/mollie_pay/sales_invoice_test.rb
+++ b/test/models/mollie_pay/sales_invoice_test.rb
@@ -1,0 +1,271 @@
+require "test_helper"
+
+module MolliePay
+  class SalesInvoiceTest < ActiveSupport::TestCase
+    test "record_from_mollie creates new record" do
+      customer = mollie_pay_customers(:acme)
+      mollie_si = fake_mollie_si(
+        id: "invoice_new123",
+        status: "issued",
+        invoice_number: "INV-0000001",
+        recipient_identifier: "cust-xyz",
+        memo: "Thank you",
+        amount_value: BigDecimal("107.69"),
+        amount_currency: "EUR",
+        issued_at: Time.current,
+        paid_at: nil,
+        due_at: 30.days.from_now
+      )
+
+      invoice = SalesInvoice.record_from_mollie(mollie_si, customer)
+
+      assert_equal "invoice_new123", invoice.mollie_id
+      assert_equal "issued", invoice.status
+      assert_equal "INV-0000001", invoice.invoice_number
+      assert_equal 10769, invoice.amount
+      assert_equal "EUR", invoice.currency
+      assert_equal "cust-xyz", invoice.recipient_identifier
+      assert_equal "Thank you", invoice.memo
+    end
+
+    test "record_from_mollie updates existing record on status change" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_sales_invoices(:acme_draft)
+
+      mollie_si = fake_mollie_si(
+        id: existing.mollie_id,
+        status: "issued",
+        invoice_number: "INV-0000002",
+        recipient_identifier: "cust-abc",
+        memo: "Updated",
+        amount_value: BigDecimal("50.00"),
+        amount_currency: "EUR",
+        issued_at: Time.current,
+        paid_at: nil,
+        due_at: 30.days.from_now
+      )
+
+      SalesInvoice.record_from_mollie(mollie_si, customer)
+
+      existing.reload
+      assert_equal "issued", existing.status
+      assert_equal "INV-0000002", existing.invoice_number
+      assert_equal 5000, existing.amount
+    end
+
+    test "record_from_mollie fires on_mollie_sales_invoice_paid on transition" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_sales_invoices(:acme_issued)
+      hook_called = false
+
+      owner = customer.owner
+      owner.define_singleton_method(:on_mollie_sales_invoice_paid) { |_si| hook_called = true }
+
+      mollie_si = fake_mollie_si(
+        id: existing.mollie_id,
+        status: "paid",
+        invoice_number: existing.invoice_number,
+        recipient_identifier: existing.recipient_identifier,
+        memo: existing.memo,
+        amount_value: BigDecimal("107.69"),
+        amount_currency: "EUR",
+        issued_at: existing.issued_at,
+        paid_at: Time.current,
+        due_at: existing.due_at
+      )
+
+      SalesInvoice.record_from_mollie(mollie_si, customer)
+
+      assert hook_called, "on_mollie_sales_invoice_paid should have been called"
+    end
+
+    test "record_from_mollie fires on_mollie_sales_invoice_issued on transition" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_sales_invoices(:acme_draft)
+      hook_called = false
+
+      owner = customer.owner
+      owner.define_singleton_method(:on_mollie_sales_invoice_issued) { |_si| hook_called = true }
+
+      mollie_si = fake_mollie_si(
+        id: existing.mollie_id,
+        status: "issued",
+        invoice_number: "INV-0000003",
+        recipient_identifier: "cust-xyz",
+        memo: "Issued now",
+        amount_value: BigDecimal("50.00"),
+        amount_currency: "EUR",
+        issued_at: Time.current,
+        paid_at: nil,
+        due_at: 30.days.from_now
+      )
+
+      SalesInvoice.record_from_mollie(mollie_si, customer)
+
+      assert hook_called, "on_mollie_sales_invoice_issued should have been called"
+    end
+
+    test "record_from_mollie does NOT fire hooks when status unchanged" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_sales_invoices(:acme_issued)
+      hook_called = false
+
+      owner = customer.owner
+      owner.define_singleton_method(:on_mollie_sales_invoice_issued) { |_si| hook_called = true }
+      owner.define_singleton_method(:on_mollie_sales_invoice_paid) { |_si| hook_called = true }
+
+      mollie_si = fake_mollie_si(
+        id: existing.mollie_id,
+        status: "issued",
+        invoice_number: existing.invoice_number,
+        recipient_identifier: existing.recipient_identifier,
+        memo: "Updated memo",
+        amount_value: BigDecimal("107.69"),
+        amount_currency: "EUR",
+        issued_at: existing.issued_at,
+        paid_at: nil,
+        due_at: existing.due_at
+      )
+
+      SalesInvoice.record_from_mollie(mollie_si, customer)
+
+      assert_not hook_called, "No hooks should have been called when status unchanged"
+    end
+
+    test "record_from_mollie handles RecordNotUnique" do
+      customer = mollie_pay_customers(:acme)
+      existing = mollie_pay_sales_invoices(:acme_issued)
+
+      mollie_si = fake_mollie_si(
+        id: existing.mollie_id,
+        status: "issued"
+      )
+
+      # Simulate a race condition by raising RecordNotUnique on update!
+      SalesInvoice.stub(:find_or_initialize_by, ->(_) {
+        raise ActiveRecord::RecordNotUnique, "duplicate"
+      }) do
+        result = SalesInvoice.record_from_mollie(mollie_si, customer)
+        assert_equal existing.id, result.id
+      end
+    end
+
+    test "draft scope returns draft invoices" do
+      draft = mollie_pay_sales_invoices(:acme_draft)
+      issued = mollie_pay_sales_invoices(:acme_issued)
+
+      assert_includes SalesInvoice.draft, draft
+      assert_not_includes SalesInvoice.draft, issued
+    end
+
+    test "issued scope returns issued invoices" do
+      issued = mollie_pay_sales_invoices(:acme_issued)
+      draft = mollie_pay_sales_invoices(:acme_draft)
+
+      assert_includes SalesInvoice.issued, issued
+      assert_not_includes SalesInvoice.issued, draft
+    end
+
+    test "paid scope returns paid invoices" do
+      assert_empty SalesInvoice.paid
+    end
+
+    test "overdue scope returns issued invoices past due" do
+      issued = mollie_pay_sales_invoices(:acme_issued)
+      issued.update!(due_at: 1.day.ago)
+
+      assert_includes SalesInvoice.overdue, issued
+    end
+
+    test "overdue scope excludes invoices not yet due" do
+      issued = mollie_pay_sales_invoices(:acme_issued)
+      issued.update!(due_at: 1.day.from_now)
+
+      assert_not_includes SalesInvoice.overdue, issued
+    end
+
+    test "requires mollie_id" do
+      invoice = SalesInvoice.new(status: "draft")
+      assert_not invoice.valid?
+      assert_includes invoice.errors[:mollie_id], "can't be blank"
+    end
+
+    test "requires unique mollie_id" do
+      existing = mollie_pay_sales_invoices(:acme_draft)
+      invoice = SalesInvoice.new(
+        mollie_id: existing.mollie_id,
+        status: "draft",
+        customer: existing.customer
+      )
+      assert_not invoice.valid?
+      assert_includes invoice.errors[:mollie_id], "has already been taken"
+    end
+
+    test "requires valid status" do
+      invoice = mollie_pay_sales_invoices(:acme_draft)
+      invoice.status = "nonsense"
+      assert_not invoice.valid?
+    end
+
+    test "requires positive amount when present" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      invoice.amount = 0
+      assert_not invoice.valid?
+
+      invoice.amount = -1
+      assert_not invoice.valid?
+    end
+
+    test "allows nil amount for drafts" do
+      invoice = mollie_pay_sales_invoices(:acme_draft)
+      invoice.amount = nil
+      invoice.currency = nil
+      assert invoice.valid?
+    end
+
+    test "status predicates" do
+      draft = mollie_pay_sales_invoices(:acme_draft)
+      assert draft.draft?
+      assert_not draft.issued?
+      assert_not draft.paid?
+      assert_not draft.canceled?
+
+      issued = mollie_pay_sales_invoices(:acme_issued)
+      assert issued.issued?
+      assert_not issued.draft?
+    end
+
+    test "amount_decimal returns amount in decimal" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      assert_in_delta 107.69, invoice.amount_decimal, 0.001
+    end
+
+    test "mollie_amount returns formatted hash" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      expected = { currency: "EUR", value: "107.69" }
+      assert_equal expected, invoice.mollie_amount
+    end
+
+    private
+
+    def fake_mollie_si(id:, status:, invoice_number: nil, recipient_identifier: nil,
+                       memo: nil, amount_value: nil, amount_currency: nil,
+                       issued_at: nil, paid_at: nil, due_at: nil)
+      total_amount = if amount_value
+        OpenStruct.new(value: amount_value, currency: amount_currency)
+      end
+
+      OpenStruct.new(
+        id: id,
+        status: status,
+        invoice_number: invoice_number,
+        recipient_identifier: recipient_identifier,
+        memo: memo,
+        total_amount: total_amount,
+        issued_at: issued_at,
+        paid_at: paid_at,
+        due_at: due_at
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `MolliePay::SalesInvoice` ActiveRecord model with migration, status tracking, and `record_from_mollie`
- Fields: mollie_id, customer_id, status, invoice_number, amount (cents), currency, recipient_identifier, memo, issued_at, paid_at, due_at
- Status constants: draft, issued, paid, canceled
- Scopes: draft, issued, paid, overdue
- `record_from_mollie(mollie_si, customer)` with previous_status check, hook dispatch, RecordNotUnique handling
- Billable hooks: `on_mollie_sales_invoice_issued`, `on_mollie_sales_invoice_paid` (no-op defaults)
- Customer association: `has_many :sales_invoices, dependent: :destroy`

This lays the foundation for Unit 2 (wiring Billable to persist invoices and mark-as-paid) and Phase 2 (webhook-driven sync).

## Test plan

- [x] 242 tests passing, rubocop clean
- [x] `record_from_mollie`: create, update, hooks on transition, no hooks when unchanged, RecordNotUnique
- [x] Scopes: draft, issued, paid, overdue
- [x] Validations: required fields, status inclusion
- [x] Status predicates, amount helpers

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: new model and migration, no changes to existing behavior. Host apps need to run `bin/rails mollie_pay:install:migrations` and `bin/rails db:migrate`.

Partial fix for #76 (Phase 1, Unit 1 of 2)