### PR TITLE
docs: Add SEPA mandate consent and compliance documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,13 @@ Public methods:
 - `mollie_subscription(name: "default")`
 - `mollie_mandate`
 - `mollie_payments` → `has_many :through` association (supports `includes`, `joins`, etc.)
+- `mollie_create_sales_invoice(lines:, status: "draft", recipient: nil, **options)` → creates sales invoice on Mollie (beta)
+- `mollie_sales_invoices(**options)` → lists sales invoices from Mollie
+- `mollie_sales_invoice(id)` → gets single sales invoice from Mollie
+- `mollie_create_mandate(method:, consumer_name:, consumer_account:, signature_date: nil)` → creates SEPA DD mandate directly (**requires prior customer consent** — see [docs/mandates.md](docs/mandates.md))
+- `mollie_revoke_mandate(mandate)` — revokes mandate on Mollie, sets local status to invalid
+- `mollie_update_customer(name: nil, email: nil, locale: nil, metadata: nil)` — syncs customer details to Mollie
+- `mollie_delete_customer` — deletes on Mollie and cascade-destroys all local records
 - `mollie_payment_methods(**options)` → delegates to `MolliePay.payment_methods`
 
 **Named subscriptions:** All subscription methods accept `name:` with a default

--- a/README.md
+++ b/README.md
@@ -102,6 +102,38 @@ current_organization.mollie_swap_subscription(name: "analytics_addon", amount: 1
 Changes take effect on the next billing cycle. See [docs/api.md](docs/api.md)
 for proration guidance.
 
+### Mandates
+
+Create SEPA Direct Debit mandates directly (for mandate migrations or
+pre-existing bank relationships):
+
+```ruby
+mandate = current_organization.mollie_create_mandate(
+  method: "directdebit",
+  consumer_name: "Jane Doe",
+  consumer_account: "NL55INGB0000000000",
+  signature_date: Date.today
+)
+```
+
+> **Important:** Direct mandate creation requires prior customer authorization.
+> See [docs/mandates.md](docs/mandates.md) for SEPA compliance requirements.
+> For most applications, use `mollie_pay_first` instead — Mollie's checkout
+> handles consent and bank authentication automatically.
+
+Revoke a mandate:
+
+```ruby
+current_organization.mollie_revoke_mandate(mandate)
+```
+
+### Customer management
+
+```ruby
+current_organization.mollie_update_customer(name: "New Name", email: "new@example.com")
+current_organization.mollie_delete_customer  # cascades to all local records
+```
+
 ### Cancel, update, and refund
 
 ```ruby
@@ -250,6 +282,7 @@ See [docs/testing.md](docs/testing.md) for the full helper reference.
 - [Tutorial](docs/tutorial.md) — step-by-step guide
 - [API Reference](docs/api.md) — data model, statuses, scopes, errors, configuration
 - [Webhooks](docs/webhooks.md) — webhook flow, chargeback detection, idempotency, Active Job
+- [Mandates](docs/mandates.md) — SEPA DD mandate consent, compliance, web signature collection
 - [Testing](docs/testing.md) — stub helpers and WebMock helpers
 - [Releasing](docs/RELEASING.md) — release process
 

--- a/docs/mandates.md
+++ b/docs/mandates.md
@@ -1,0 +1,199 @@
+# SEPA Direct Debit Mandates
+
+A SEPA Direct Debit mandate is a legal authorization from a customer allowing you
+to debit their bank account. MolliePay supports two ways to create mandates, each
+with different compliance obligations.
+
+## Two Paths to Mandates
+
+### Path 1: First Payment (Recommended)
+
+Use `mollie_pay_first` to create a payment with `sequenceType: "first"`. The
+customer is redirected to Mollie's checkout, where their bank authenticates them
+with Strong Customer Authentication (SCA). On success, Mollie automatically
+creates a `directdebit` mandate.
+
+```ruby
+payment = current_organization.mollie_pay_first(
+  amount: 100, description: "Activation fee"
+)
+redirect_to payment.checkout_url
+```
+
+**This is the recommended approach for most applications.** Mollie's checkout
+handles consent display, bank authentication, and mandate creation. Your
+compliance obligations are minimal.
+
+### Path 2: Direct Mandate Creation
+
+Use `mollie_create_mandate` to create a SEPA DD mandate directly from an IBAN.
+This is useful for migrating mandates from another provider or when you already
+have a bank relationship with the customer.
+
+```ruby
+mandate = current_organization.mollie_create_mandate(
+  method: "directdebit",
+  consumer_name: "Jane Doe",
+  consumer_account: "NL55INGB0000000000",
+  signature_date: Date.today
+)
+```
+
+> **You are legally responsible for collecting customer authorization before
+> calling this method.** Mollie's checkout is not involved — there is no bank
+> authentication or consent display. See the requirements below.
+
+### Comparison
+
+| Aspect | First Payment | Direct Creation |
+|--------|--------------|-----------------|
+| Bank authentication (SCA) | Yes — handled by bank | No |
+| Consent text display | Handled by Mollie checkout | Your responsibility |
+| Proof of consent | Bank authentication | You must collect and store |
+| Dispute risk | Lower (authorized mandate) | Higher (you must prove consent) |
+| Best for | Most SaaS applications | Mandate migrations, pre-existing relationships |
+| Method | `mollie_pay_first` | `mollie_create_mandate` |
+
+## Legal Requirements for Direct Mandate Creation
+
+When using `mollie_create_mandate`, the European Payments Council (EPC) SEPA
+Direct Debit Core Rulebook requires you to:
+
+### 1. Display the Mandate Authorization Text
+
+You must show the customer the following standard text (or equivalent in their
+language) before they authorize the mandate:
+
+> By signing this mandate form, you authorise (A) **{YOUR COMPANY NAME}** to
+> send instructions to your bank to debit your account and (B) your bank to
+> debit your account in accordance with the instructions from **{YOUR COMPANY
+> NAME}**.
+>
+> As part of your rights, you are entitled to a refund from your bank under the
+> terms and conditions of your agreement with your bank. A refund must be
+> claimed within 8 weeks starting from the date on which your account was
+> debited. Your rights are explained in a statement that you can obtain from
+> your bank.
+
+Replace `{YOUR COMPANY NAME}` with your business name. Note that Mollie acts as
+the creditor of record (Creditor Identifier: `NL08ZZZ502057730000`), so Mollie's
+name appears on the customer's bank statement.
+
+### 2. Collect Required Information
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| Full name | Account holder name | Yes |
+| IBAN | International Bank Account Number | Yes |
+| Explicit consent | Customer actively accepts the mandate | Yes |
+| BIC | Bank Identifier Code | Optional (derived from IBAN) |
+
+### 3. Record Proof of Consent
+
+When the customer accepts the mandate on your website, record:
+
+- **Timestamp** — exact date and time of acceptance
+- **IP address** — the customer's IP at time of acceptance
+- **User agent** — browser identification string
+- **Mandate text version** — the exact text the customer agreed to
+- **Customer identifiers** — name, email, account used
+
+Pass the consent date to Mollie via the `signature_date` parameter:
+
+```ruby
+mandate = current_organization.mollie_create_mandate(
+  method: "directdebit",
+  consumer_name: "Jane Doe",
+  consumer_account: "NL55INGB0000000000",
+  signature_date: Date.today
+)
+```
+
+### 4. Store Records
+
+Mandate consent records must be stored for:
+
+- **Active mandates**: entire duration the mandate is active
+- **After last collection**: at least **36 months** after the final debit
+- **Best practice**: retain for **10 years** (varies by national law)
+
+Records must be stored in a way that prevents modification (integrity
+protection). If a customer disputes a debit, you must be able to produce
+the mandate as evidence.
+
+### 5. Communicate to the Customer
+
+After the customer accepts:
+
+1. **Confirmation**: Show the mandate details on a confirmation page or send
+   via email immediately
+2. **Pre-notification**: Notify the customer at least **14 calendar days** before
+   each debit (can be shortened to a minimum of 2 days by written agreement
+   with the customer)
+
+## Collecting Consent on the Web
+
+### Recommended Approach
+
+Display the full mandate text on a dedicated form page. The customer fills in
+their name and IBAN, reads the authorization text, and submits the form. The
+form submission constitutes their consent.
+
+A well-designed consent form includes:
+
+1. IBAN and name input fields
+2. The full EPC mandate authorization text (visible, not behind a link)
+3. A clear submit button with text like "Authorize Direct Debit"
+4. Recording of timestamp, IP, and user agent on submission
+
+### Is a Checkbox Sufficient?
+
+A simple checkbox is a "Simple Electronic Signature" (SES) under the EU's eIDAS
+Regulation. For SEPA Core Direct Debit (consumer-facing), this is accepted in
+practice when combined with visible mandate text and proper record-keeping.
+
+For SEPA B2B Direct Debit (business-to-business), an Advanced Electronic
+Signature (AES) or Qualified Electronic Signature (QES) is required. This is
+beyond what a checkbox provides — consider a dedicated e-signature service.
+
+### Legal Standing
+
+Under eIDAS Regulation (EU No 910/2014), electronic signatures cannot be denied
+legal effect solely because they are electronic. E-mandates collected via web
+forms are valid across all 36 SEPA countries when they comply with the
+requirements above.
+
+The key factor in disputes is **evidence quality**, not signature type. A form
+submission with timestamp, IP address, displayed mandate text, and stored consent
+record is defensible. A mandate created with no consent evidence is not.
+
+## Revoking Mandates
+
+Customers can request mandate revocation at any time. Use `mollie_revoke_mandate`
+to revoke on Mollie's side and update the local record:
+
+```ruby
+mandate = current_organization.mollie_mandate
+current_organization.mollie_revoke_mandate(mandate)
+```
+
+This sets the mandate status to `invalid` locally and on Mollie. Any active
+subscriptions using this mandate should be canceled separately.
+
+## Quick Reference
+
+| Obligation | First Payment | Direct Creation |
+|------------|:------------:|:---------------:|
+| Display mandate text | Mollie handles | You |
+| Collect IBAN + name | Mollie handles | You |
+| Record consent proof | Bank auth | You |
+| Store records 36+ months | Recommended | Required |
+| Pre-notify before debits | Recommended | Required |
+| Send mandate copy | Mollie handles | You |
+
+## References
+
+- [EPC SEPA DD Mandate Requirements](https://www.europeanpaymentscouncil.eu/what-we-do/epc-payment-schemes/sepa-direct-debit/sdd-mandate)
+- [Mollie Recurring Payments](https://docs.mollie.com/docs/recurring-payments)
+- [Mollie Create Mandate API](https://docs.mollie.com/reference/create-mandate)
+- [eIDAS Regulation (EU No 910/2014)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2014.257.01.0073.01.ENG)

--- a/docs/plans/2026-03-26-003-docs-sepa-mandate-consent-documentation-plan.md
+++ b/docs/plans/2026-03-26-003-docs-sepa-mandate-consent-documentation-plan.md
@@ -1,0 +1,133 @@
+---
+title: "docs: Add SEPA mandate consent and compliance documentation"
+type: feat
+status: active
+date: 2026-03-26
+---
+
+# docs: Add SEPA mandate consent and compliance documentation
+
+## Overview
+
+Add comprehensive documentation about SEPA Direct Debit mandate consent requirements for `mollie_create_mandate`. Host app developers using direct mandate creation (bypassing Mollie's checkout) are legally responsible for collecting customer authorization, displaying mandate text, and maintaining consent records. This is currently undocumented.
+
+## Problem Frame
+
+PR #83 added `mollie_create_mandate` for direct SEPA DD mandate creation. Unlike `mollie_pay_first` (where Mollie's checkout handles consent and SCA), the direct API path places the full legal compliance burden on the host app. Without documentation, developers may create mandates without proper customer authorization, exposing themselves to dispute risk and potential regulatory issues.
+
+The EPC SEPA DD Core Rulebook requires: signed mandate with specific text, debtor IBAN and name, creditor identifier, signature date, and immutable storage for 36+ months. Web collection requires displaying the full mandate text and recording consent proof (timestamp, IP, user agent).
+
+## Requirements Trace
+
+- R1. Create `docs/mandates.md` comprehensive guide covering both mandate creation paths
+- R2. Document the legally required EPC mandate authorization text
+- R3. Document what the host app must collect, display, and store for direct mandate creation
+- R4. Document web signature collection best practices and legal standing
+- R5. Update README.md with mandate create/revoke examples and compliance pointer
+- R6. Update AGENTS.md with new Billable methods from PR #83
+- R7. Add `signatureDate` recommendation to `mollie_create_mandate` — pass it through to Mollie as evidence of consent timing
+
+## Scope Boundaries
+
+- No enforcement of consent collection in code — the gem documents requirements, host apps implement consent flows
+- No mandate text template generator — provide the text, host apps render it
+- No consent storage model — document what to store, host apps choose how
+
+## Key Technical Decisions
+
+- **Dedicated `docs/mandates.md`**: Follows the existing pattern of feature-area docs (`webhooks.md`, `testing.md`). Mandates deserve their own guide given the legal complexity.
+- **Two-path documentation**: Clearly distinguish `mollie_pay_first` (recommended, PSP handles consent) from `mollie_create_mandate` (direct, merchant handles consent). Most developers should use the first path.
+- **`signatureDate` pass-through**: The Mollie API accepts `signatureDate` on mandate creation. Document and recommend passing it as evidence of when consent was collected.
+
+## Implementation Units
+
+- [ ] **Unit 1: Create `docs/mandates.md` compliance guide**
+
+  **Goal:** Comprehensive guide covering SEPA DD mandate requirements, both creation paths, web consent collection, and record-keeping obligations.
+
+  **Requirements:** R1, R2, R3, R4
+
+  **Files:**
+  - Create: `docs/mandates.md`
+
+  **Approach:**
+  - Section 1: Overview of SEPA DD mandates and why authorization matters
+  - Section 2: Two paths compared (first payment vs direct creation) with recommendation
+  - Section 3: Legal requirements for direct mandate creation — EPC mandate text (verbatim), required fields, creditor identifier info (Mollie's CI: NL08ZZZ502057730000)
+  - Section 4: Collecting consent on the web — display mandate text, explicit acceptance, record proof (timestamp, IP, user agent, text version), store immutably 36+ months
+  - Section 5: What to communicate to the customer — confirmation page or email with mandate copy, pre-notification before debits (14 days standard)
+  - Section 6: Code examples for both paths
+  - Section 7: Record-keeping summary table
+  - Include the standard EPC authorization text template with placeholder markers
+
+  **Patterns to follow:**
+  - `docs/webhooks.md` for guide structure and depth
+  - `docs/tutorial.md` callout box pattern for warnings
+
+  **Verification:**
+  - Guide covers both mandate creation paths with clear recommendation
+  - EPC mandate text is included verbatim
+  - Host app obligations are concrete and actionable
+
+- [ ] **Unit 2: Update README.md and AGENTS.md**
+
+  **Goal:** Document `mollie_create_mandate`, `mollie_revoke_mandate`, `mollie_update_customer`, `mollie_delete_customer` in the public API references with a compliance pointer.
+
+  **Requirements:** R5, R6
+
+  **Files:**
+  - Modify: `README.md`
+  - Modify: `AGENTS.md`
+
+  **Approach:**
+  - README: Add "Mandates" section after subscriptions with create/revoke examples, prominent note linking to `docs/mandates.md` for compliance requirements
+  - README: Add "Customer management" section with update/delete examples
+  - AGENTS.md: Add all four new Billable methods to the public methods list
+  - AGENTS.md: Add `mollie_create_mandate`, `mollie_revoke_mandate`, `mollie_update_customer`, `mollie_delete_customer` with parameter signatures
+  - Both: Include a brief warning that `mollie_create_mandate` requires prior customer consent
+
+  **Patterns to follow:**
+  - README payment methods section for code examples
+  - AGENTS.md Billable methods list format
+
+  **Verification:**
+  - All new Billable methods are documented in both files
+  - Compliance warning is visible near `mollie_create_mandate`
+
+- [ ] **Unit 3: Add `signature_date` parameter and documentation to `mollie_create_mandate`**
+
+  **Goal:** Document and recommend the `signature_date` parameter on `mollie_create_mandate` as evidence of consent timing.
+
+  **Requirements:** R7
+
+  **Files:**
+  - Modify: `app/models/mollie_pay/billable.rb` (add `signature_date:` named parameter)
+  - Modify: `test/models/mollie_pay/billable_test.rb`
+
+  **Approach:**
+  - Add `signature_date: nil` parameter to `mollie_create_mandate`
+  - When provided, pass as `signatureDate: signature_date.to_s` to Mollie API
+  - Document in the mandates guide that passing `signature_date: Date.today` is recommended
+  - Test that `signatureDate` is forwarded to the Mollie API when provided
+
+  **Patterns to follow:**
+  - `mollie_subscribe` for optional parameter handling (e.g., `start_date`)
+
+  **Test scenarios:**
+  - `mollie_create_mandate` forwards `signatureDate` to Mollie when provided
+  - `mollie_create_mandate` omits `signatureDate` when not provided
+
+  **Verification:**
+  - Parameter is accepted and forwarded correctly
+  - Documented in mandates guide with recommendation
+
+## Sources & References
+
+- EPC SEPA DD Core Rulebook: https://www.europeanpaymentscouncil.eu/what-we-do/epc-payment-schemes/sepa-direct-debit
+- Mollie Create Mandate: https://docs.mollie.com/reference/create-mandate
+- Mollie Creditor Identifier: NL08ZZZ502057730000
+- Mollie Recurring Payments: https://docs.mollie.com/docs/recurring-payments
+- eIDAS Regulation (EU No 910/2014) on electronic signatures
+- GoCardless Mandate Contents: https://gocardless.com/en-us/guides/sepa/mandate-contents/
+- Related PR: #83
+- Related issue: #78


### PR DESCRIPTION
## Summary

- Add comprehensive `docs/mandates.md` guide covering SEPA Direct Debit mandate legal requirements
- Document both mandate creation paths (first payment vs direct) with clear compliance comparison
- Include verbatim EPC mandate authorization text template
- Cover web consent collection best practices, legal standing under eIDAS, and record-keeping requirements
- Update README.md with mandate create/revoke and customer management examples
- Update AGENTS.md with all new Billable methods from PRs #75, #82, #83

## Why this matters

`mollie_create_mandate` (PR #83) creates SEPA DD mandates directly from an IBAN. Unlike `mollie_pay_first`, this bypasses Mollie's checkout — the host app is legally responsible for collecting customer authorization. Without documentation, developers may create mandates without proper consent, exposing themselves to dispute risk and SEPA scheme violations.

## Key content in docs/mandates.md

1. Two-path comparison table (first payment recommended vs direct creation)
2. EPC-mandated authorization text (verbatim, with placeholder markers)
3. Required information to collect (name, IBAN, explicit consent)
4. How to record proof of consent (timestamp, IP, user agent, text version)
5. Storage requirements (36+ months, integrity-protected)
6. Web signature legal standing under eIDAS Regulation
7. Pre-notification obligations (14 days before each debit)

## Test plan

- [x] 231 tests passing, rubocop clean
- [x] No code changes beyond documentation and AGENTS.md updates

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: documentation-only change.

Related: #78, #83