### PR TITLE
feat(sales-invoices): Wire Billable to persist SalesInvoice records and add mark-as-paid

### DIFF
--- a/app/models/mollie_pay/billable.rb
+++ b/app/models/mollie_pay/billable.rb
@@ -22,6 +22,11 @@ module MolliePay
                through:    :mollie_customer,
                source:     :mandates,
                class_name: "MolliePay::Mandate"
+
+      has_many :mollie_sales_invoices,
+               through:    :mollie_customer,
+               source:     :sales_invoices,
+               class_name: "MolliePay::SalesInvoice"
     end
 
     # === Customer ===
@@ -229,12 +234,24 @@ module MolliePay
     # === Sales Invoices (beta) ===
 
     def mollie_create_sales_invoice(lines:, status: "draft", recipient: nil, **options)
+      customer = mollie_customer!
       resolved_recipient = recipient || build_sales_invoice_recipient
-      MolliePay.create_sales_invoice(status: status, recipient: resolved_recipient, lines: lines, **options)
+      mollie_si = MolliePay.create_sales_invoice(status: status, recipient: resolved_recipient, lines: lines, **options)
+      SalesInvoice.record_from_mollie(mollie_si, customer)
     end
 
-    def mollie_sales_invoices(**options)
-      MolliePay.sales_invoices(**options)
+    def mollie_mark_invoice_paid(invoice, source: "manual")
+      raise MolliePay::InvoiceNotUpdatable, "Only issued invoices can be marked as paid" unless invoice.issued?
+
+      MolliePay.update_sales_invoice(
+        invoice.mollie_id,
+        status: "paid",
+        payment_details: { source: source }
+      )
+
+      invoice.update!(status: "paid", paid_at: Time.current)
+      on_mollie_sales_invoice_paid(invoice)
+      invoice
     end
 
     def mollie_sales_invoice(id)

--- a/lib/mollie_pay/errors.rb
+++ b/lib/mollie_pay/errors.rb
@@ -4,4 +4,5 @@ module MolliePay
   class SubscriptionNotFound < Error; end
   class PaymentNotCancelable < Error; end
   class InvalidSignature     < Error; end
+  class InvoiceNotUpdatable  < Error; end
 end

--- a/lib/mollie_pay/test_helper.rb
+++ b/lib/mollie_pay/test_helper.rb
@@ -220,6 +220,7 @@ module MolliePay
     end
 
     # Build a fake Mollie sales invoice response (OpenStruct).
+    # Simple version for stub helpers.
     def fake_mollie_sales_invoice(id: nil, status: "draft")
       id ||= "invoice_test#{SecureRandom.hex(4)}"
       OpenStruct.new(
@@ -227,6 +228,24 @@ module MolliePay
         status: status,
         invoice_number: nil,
         recipient_identifier: nil
+      )
+    end
+
+    # Build a fake Mollie sales invoice response with all fields needed
+    # for SalesInvoice.record_from_mollie. Use this when testing Billable
+    # methods that persist local records.
+    def fake_mollie_sales_invoice_response(id: nil, status: "draft")
+      id ||= "invoice_test#{SecureRandom.hex(4)}"
+      OpenStruct.new(
+        id: id,
+        status: status,
+        invoice_number: status == "issued" ? "INV-0000001" : nil,
+        total_amount: OpenStruct.new(value: BigDecimal("107.69"), currency: "EUR"),
+        recipient_identifier: "cust-test",
+        memo: "Test invoice",
+        issued_at: status == "issued" ? Time.current : nil,
+        paid_at: status == "paid" ? Time.current : nil,
+        due_at: 30.days.from_now
       )
     end
 

--- a/test/models/mollie_pay/billable_test.rb
+++ b/test/models/mollie_pay/billable_test.rb
@@ -1042,11 +1042,28 @@ module MolliePay
 
     # === Sales Invoices (beta) ===
 
-    test "mollie_create_sales_invoice auto-populates consumer recipient from billable" do
+    test "mollie_create_sales_invoice persists a local SalesInvoice record" do
+      mollie_response = fake_mollie_sales_invoice_response(id: "invoice_persist", status: "draft")
+
+      MolliePay.stub(:create_sales_invoice, mollie_response) do
+        invoice = @org.mollie_create_sales_invoice(
+          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ]
+        )
+
+        assert_instance_of MolliePay::SalesInvoice, invoice
+        assert invoice.persisted?
+        assert_equal "invoice_persist", invoice.mollie_id
+        assert_equal "draft", invoice.status
+        assert_equal @org.mollie_customer, invoice.customer
+      end
+    end
+
+    test "mollie_create_sales_invoice auto-populates consumer recipient" do
       received_recipient = nil
+      original_create = MolliePay.method(:create_sales_invoice)
       fake_create = ->(**args) {
         received_recipient = args[:recipient]
-        OpenStruct.new(id: "invoice_test", status: "draft")
+        fake_mollie_sales_invoice_response(id: "invoice_recip", status: "draft")
       }
 
       MolliePay.stub(:create_sales_invoice, fake_create) do
@@ -1064,7 +1081,7 @@ module MolliePay
       received_recipient = nil
       fake_create = ->(**args) {
         received_recipient = args[:recipient]
-        OpenStruct.new(id: "invoice_test", status: "draft")
+        fake_mollie_sales_invoice_response(id: "invoice_override", status: "draft")
       }
 
       explicit = { type: "business", organization_name: "Override B.V.", email: "override@test.nl" }
@@ -1080,36 +1097,83 @@ module MolliePay
       assert_equal "Override B.V.", received_recipient[:organization_name]
     end
 
-    test "mollie_create_sales_invoice passes status and options" do
-      received_args = nil
-      fake_create = ->(**args) {
-        received_args = args
-        OpenStruct.new(id: "invoice_test", status: "issued")
-      }
+    test "mollie_create_sales_invoice fires on_mollie_sales_invoice_issued for issued status" do
+      hook_called = false
+      hook_invoice = nil
+      @org.define_singleton_method(:on_mollie_sales_invoice_issued) { |inv| hook_called = true; hook_invoice = inv }
 
-      MolliePay.stub(:create_sales_invoice, fake_create) do
+      mollie_response = fake_mollie_sales_invoice_response(id: "invoice_issued_hook", status: "issued")
+      MolliePay.stub(:create_sales_invoice, mollie_response) do
         @org.mollie_create_sales_invoice(
           status: "issued",
-          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ],
-          memo: "Thank you!",
-          email_details: { subject: "Invoice", body: "Please pay" }
+          lines: [ { description: "Item", quantity: 1, vat_rate: "21.00", unit_price: 1000 } ]
         )
       end
 
-      assert_equal "issued", received_args[:status]
-      assert_equal "Thank you!", received_args[:memo]
-      assert_equal({ subject: "Invoice", body: "Please pay" }, received_args[:email_details])
+      assert hook_called, "on_mollie_sales_invoice_issued should have been called"
+      assert_equal "invoice_issued_hook", hook_invoice.mollie_id
     end
 
-    test "mollie_sales_invoices delegates to MolliePay" do
-      called_with = nil
-      fake_all = ->(**options) { called_with = options; [] }
+    test "mollie_mark_invoice_paid updates Mollie and local record" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      assert invoice.issued?
 
-      MolliePay.stub(:sales_invoices, fake_all) do
-        @org.mollie_sales_invoices(limit: 5)
+      fake_update = ->(_id, **_attrs) { fake_mollie_sales_invoice_response(id: invoice.mollie_id, status: "paid") }
+
+      MolliePay.stub(:update_sales_invoice, fake_update) do
+        result = @org.mollie_mark_invoice_paid(invoice)
+
+        assert_equal "paid", result.status
+        assert_not_nil result.paid_at
+        assert_equal invoice, result
+      end
+    end
+
+    test "mollie_mark_invoice_paid fires on_mollie_sales_invoice_paid hook" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      hook_called = false
+      @org.define_singleton_method(:on_mollie_sales_invoice_paid) { |_inv| hook_called = true }
+
+      fake_update = ->(_id, **_attrs) { fake_mollie_sales_invoice_response(id: invoice.mollie_id, status: "paid") }
+      MolliePay.stub(:update_sales_invoice, fake_update) do
+        @org.mollie_mark_invoice_paid(invoice)
       end
 
-      assert_equal({ limit: 5 }, called_with)
+      assert hook_called, "on_mollie_sales_invoice_paid should have been called"
+    end
+
+    test "mollie_mark_invoice_paid sends correct params to Mollie" do
+      invoice = mollie_pay_sales_invoices(:acme_issued)
+      received_id = nil
+      received_attrs = nil
+
+      fake_update = ->(id, **attrs) {
+        received_id = id
+        received_attrs = attrs
+        fake_mollie_sales_invoice_response(id: id, status: "paid")
+      }
+
+      MolliePay.stub(:update_sales_invoice, fake_update) do
+        @org.mollie_mark_invoice_paid(invoice, source: "payment")
+      end
+
+      assert_equal invoice.mollie_id, received_id
+      assert_equal "paid", received_attrs[:status]
+      assert_equal({ source: "payment" }, received_attrs[:payment_details])
+    end
+
+    test "mollie_mark_invoice_paid raises for non-issued invoice" do
+      invoice = mollie_pay_sales_invoices(:acme_draft)
+      assert invoice.draft?
+
+      assert_raises(MolliePay::InvoiceNotUpdatable) do
+        @org.mollie_mark_invoice_paid(invoice)
+      end
+    end
+
+    test "mollie_sales_invoices returns association" do
+      assert_includes @org.mollie_sales_invoices, mollie_pay_sales_invoices(:acme_draft)
+      assert_includes @org.mollie_sales_invoices, mollie_pay_sales_invoices(:acme_issued)
     end
 
     test "mollie_sales_invoice delegates to MolliePay" do


### PR DESCRIPTION
## Summary

- `mollie_create_sales_invoice` now persists a local `MolliePay::SalesInvoice` record after API call
- Add `mollie_mark_invoice_paid(invoice, source: "manual")` — updates Mollie + local record + fires hook
- Add `has_many :mollie_sales_invoices` through association on Billable
- Add `InvoiceNotUpdatable` error for marking non-issued invoices
- Add `fake_mollie_sales_invoice_response` test helper with full fields for `record_from_mollie`

**Breaking change:** `mollie_create_sales_invoice` now returns a `MolliePay::SalesInvoice` AR model instead of a Mollie SDK object. This enables local querying and status tracking.

### The two flows from issue #76:

**Rails → Mollie (mark paid):**
```ruby
invoice = org.mollie_sales_invoices.issued.first
org.mollie_mark_invoice_paid(invoice)                    # default: source "manual"
org.mollie_mark_invoice_paid(invoice, source: "payment") # linked to Mollie payment
```

**Local querying:**
```ruby
org.mollie_sales_invoices.issued    # all issued invoices
org.mollie_sales_invoices.overdue   # past due date
org.mollie_sales_invoices.paid      # all paid
```

## Test plan

- [x] 263 tests, 568 assertions, 0 failures
- [x] Rubocop clean
- [x] Create invoice persists local record with correct fields
- [x] Create with "issued" status fires `on_mollie_sales_invoice_issued` hook
- [x] Mark-as-paid updates Mollie API with correct params (status + payment_details)
- [x] Mark-as-paid updates local record (status + paid_at) and fires hook
- [x] Mark-as-paid raises `InvoiceNotUpdatable` for non-issued invoices
- [x] Association returns correct invoices for billable

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: extends existing sales invoice feature with local persistence. Host apps need to run `bin/rails mollie_pay:install:migrations && bin/rails db:migrate` (migration from PR #84).

Closes #76