### PR TITLE
chore: Bump version to 0.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,11 @@ app/
     chargeback.rb
     payment.rb
     refund.rb
+    sales_invoice.rb
     subscription.rb
 lib/
+  mollie/
+    sales_invoice.rb        # SDK extension for /v2/sales-invoices endpoint
   mollie_pay/
     configuration.rb
     engine.rb
@@ -186,9 +189,10 @@ Public methods:
 - `mollie_subscription(name: "default")`
 - `mollie_mandate`
 - `mollie_payments` → `has_many :through` association (supports `includes`, `joins`, etc.)
-- `mollie_create_sales_invoice(lines:, status: "draft", recipient: nil, **options)` → creates sales invoice on Mollie (beta)
-- `mollie_sales_invoices(**options)` → lists sales invoices from Mollie
-- `mollie_sales_invoice(id)` → gets single sales invoice from Mollie
+- `mollie_create_sales_invoice(lines:, status: "draft", recipient: nil, **options)` → creates on Mollie and persists local `SalesInvoice` record (beta)
+- `mollie_mark_invoice_paid(invoice, source: "manual")` → marks issued invoice as paid on Mollie + local record, fires hook
+- `mollie_sales_invoices` → `has_many :through` association (supports scopes: `.issued`, `.paid`, `.overdue`)
+- `mollie_sales_invoice(id)` → gets single sales invoice from Mollie API
 - `mollie_create_mandate(method:, consumer_name:, consumer_account:, signature_date: nil)` → creates SEPA DD mandate directly (**requires prior customer consent** — see [docs/mandates.md](docs/mandates.md))
 - `mollie_revoke_mandate(mandate)` — revokes mandate on Mollie, sets local status to invalid
 - `mollie_update_customer(name: nil, email: nil, locale: nil, metadata: nil)` — syncs customer details to Mollie
@@ -215,6 +219,8 @@ Event hooks (override in host model, all no-ops by default):
 - `on_mollie_chargeback_received`
 - `on_mollie_chargeback_reversed`
 - `on_mollie_subscription_swapped(subscription, previous_amount:, previous_interval:)`
+- `on_mollie_sales_invoice_issued`
+- `on_mollie_sales_invoice_paid`
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    mollie_pay (0.4.0)
+    mollie_pay (0.5.0)
       mollie-api-ruby (>= 4.19.0)
       rails (>= 8.1.2)
 
@@ -350,7 +350,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   mollie-api-ruby (4.19.0)
-  mollie_pay (0.4.0)
+  mollie_pay (0.5.0)
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/mollie_pay/version.rb
+++ b/lib/mollie_pay/version.rb
@@ -1,3 +1,3 @@
 module MolliePay
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
## Summary

Version bump to 0.5.0 with AGENTS.md updates reflecting all new features.

### What's in v0.5.0

**Sales Invoices (beta):**
- `Mollie::SalesInvoice` SDK extension for `/v2/sales-invoices` (#75)
- `MolliePay::SalesInvoice` AR model with `record_from_mollie` (#84)
- `mollie_create_sales_invoice` persists local records (#86)
- `mollie_mark_invoice_paid` for Rails → Mollie payment marking (#86)
- `mollie_sales_invoices` association for local querying (#86)
- Hooks: `on_mollie_sales_invoice_issued`, `on_mollie_sales_invoice_paid`

**Mandate operations:**
- `mollie_create_mandate` for direct SEPA DD mandate creation (#83)
- `mollie_revoke_mandate` to revoke mandates (#83)
- SEPA mandate consent & compliance guide (`docs/mandates.md`) (#85)

**Customer management:**
- `mollie_update_customer` to sync changes to Mollie (#82)
- `mollie_delete_customer` with cascade destroy for GDPR (#82)

**Infrastructure:**
- Next-gen webhooks with HMAC-SHA256 verification (#71)

### Migration required

Host apps upgrading to 0.5.0 need to run:
```sh
bin/rails mollie_pay:install:migrations
bin/rails db:migrate
```

## Test plan

- [x] 263 tests, 568 assertions, 0 failures
- [x] Rubocop clean